### PR TITLE
refactor: GetTextureHandle()を定義しGLViewのゲッターを削除

### DIFF
--- a/src/FloatSoda.Engine/DashboardWindow.cs
+++ b/src/FloatSoda.Engine/DashboardWindow.cs
@@ -60,7 +60,7 @@ public class DashboardWindow : IWindow
         _renderer.Render(Root);
         var texture = new Texture_t
         {
-            handle = _renderer.GLView.TextureHandle,
+            handle = _renderer.GetTextureHandle(),
             eType = ETextureType.OpenGL,
             eColorSpace = EColorSpace.Auto,
         };

--- a/src/FloatSoda.Engine/FloatingWindow.cs
+++ b/src/FloatSoda.Engine/FloatingWindow.cs
@@ -62,7 +62,7 @@ public class FloatingWindow : IWindow
 
         var texture = new Texture_t
         {
-            handle = _renderer.GLView.TextureHandle,
+            handle = _renderer.GetTextureHandle(),
             eType = ETextureType.OpenGL,
             eColorSpace = EColorSpace.Auto,
         };

--- a/src/FloatSoda.Engine/Render/Renderer.cs
+++ b/src/FloatSoda.Engine/Render/Renderer.cs
@@ -4,8 +4,9 @@ namespace FloatSoda.Engine.Render;
 
 public class Renderer(GLView glView) : IDisposable
 {
-    public GLView GLView => glView;
     private readonly RenderContext _renderContext = RenderContext.Create(glView.Surface);
+
+    public IntPtr GetTextureHandle() => glView.TextureHandle;
 
     public void Render(ILayer root)
     {


### PR DESCRIPTION
Fix #9  