### PR TITLE
feat(Widget/Element): Widget・Elementシステムの実装とレンダリングパイプライン統合

### DIFF
--- a/samples/FloatSoda.Samples.PaintingSample/Program.cs
+++ b/samples/FloatSoda.Samples.PaintingSample/Program.cs
@@ -37,19 +37,13 @@ ILayer CreateLayerTree(float width, float height)
     var recorder = new SKPictureRecorder();
     var canvas = recorder.BeginRecording(rect);
 
-    var paint = new SKPaint
-    {
-        Color = SKColors.Tomato
-    };
-
-    var alignment = new Alignment();
+    canvas.DrawRect(rect, new SKPaint { Color = SKColors.AliceBlue });
 
     var parentSize = new SKSize(width, height);
-    var childSize = new SKSize(width / 4, height / 4);
+    var childSize = new SKSize(width / 2, height / 2);
+    var location = new Alignment().ComputeOffset(parentSize, childSize);
 
-    var location = alignment.ComputeOffset(parentSize, childSize);
-
-    canvas.DrawRect(SKRect.Create(location, parentSize), paint);
+    canvas.DrawRect(SKRect.Create(location, childSize), new SKPaint { Color = SKColors.CornflowerBlue });
 
     leaf.Picture = recorder.EndRecording();
 


### PR DESCRIPTION
## Summary

- Widget/Elementシステム（`StatelessWidget`, `StatefulWidget`, `RenderObjectWidget`, `Element` 等）を実装し、Flutter的な宣言的UIツリーを構築できるようにした
- `RenderPipeline` にダーティノード管理と `OnNeedVisualUpdate` コールバックを追加し、WidgetツリーからRenderObjectへの変更通知フローを確立
- `WidgetBinding` クラスを新設して Widget → RenderObject → レンダースレッドの接続を一元管理
- `EventDispatcher` を抽象クラスに再設計し `VRSystemEventDispatcher` に分離
- `ThreadRunner`/`RenderThreadRunner` を `TaskRunner`/`RenderTaskRunner` にリネーム
- スタブ実装だったClip系・`ColoredBox` ウィジェットを `SingleChildRenderObjectWidget` ベースの実装に置き換え
- `PaintingSample` で Layer / RenderObject / Widget の3ツリーを実際に描画できるよう更新し、`CreateLayerTree` の出力を `CreateWidgetTree` と一致させた

## Changes

| ファイル | 内容 |
|---|---|
| `src/FloatSoda/Widgets/` | Widget基底クラス群と各種ウィジェット実装 |
| `src/FloatSoda/Elements/` | Element基底クラス群 |
| `src/FloatSoda/WidgetBinding.cs` | Widgetツリーをレンダースレッドに繋ぐ統合クラス |
| `src/FloatSoda/Render/RenderPipeline.cs` | ダーティ管理・`OnNeedVisualUpdate` コールバック追加 |
| `src/FloatSoda.Engine/` | `TaskRunner`/`RenderTaskRunner` へのリネーム |
| `samples/FloatSoda.Samples.PaintingSample/Program.cs` | 3ツリーの描画サンプル更新・`CreateLayerTree` 修正 |

## Test plan

- [ ] `dotnet build` でビルドエラーなし
- [ ] `PaintingSample` を実行し `layer_tree_output.png` / `render_tree_output.png` / `widget_tree_output.png` の3ファイルが同等の描画（AliceBlue背景 + 中央CornflowerBlueボックス）で出力されることを確認
- [ ] `dotnet test tests/FloatSoda.GeometryTest` がグリーンを維持

🤖 Generated with [Claude Code](https://claude.com/claude-code)