### PR TITLE
feat(Widget/Element/Test): Widget/Elementシステムの実装とレイヤーテストの追加

### DIFF
--- a/tests/FloatSoda.Common.Test/FloatSoda.Common.Test.csproj
+++ b/tests/FloatSoda.Common.Test/FloatSoda.Common.Test.csproj
@@ -23,8 +23,5 @@
     <ProjectReference Include="..\..\src\FloatSoda\FloatSoda.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Folder Include="Geometrics\" />
-  </ItemGroup>
 
 </Project>

--- a/tests/FloatSoda.Common.Test/Layers/LayerTest.cs
+++ b/tests/FloatSoda.Common.Test/Layers/LayerTest.cs
@@ -1,0 +1,107 @@
+using FloatSoda.Common.Layer;
+using FloatSoda.Rendering;
+using SkiaSharp;
+
+namespace FloatSoda.Common.Test.Layers;
+
+public class LayerTest
+{
+    private static readonly ImageRenderer Renderer = new();
+    private static readonly SKSizeI Size = new(100, 100);
+
+    private static PictureLayer MakePicture(SKColor color, SKRect rect)
+    {
+        using var recorder = new SKPictureRecorder();
+        var canvas = recorder.BeginRecording(rect);
+        using var paint = new SKPaint { Color = color };
+        canvas.DrawRect(rect, paint);
+        return new PictureLayer { Picture = recorder.EndRecording() };
+    }
+
+    [Fact]
+    public void PictureLayer_PaintsColor()
+    {
+        var layer = MakePicture(SKColors.Red, SKRect.Create(0, 0, 100, 100));
+
+        using var bitmap = Renderer.RenderLayerTreeToBitmap(layer, Size);
+
+        Assert.Equal(SKColors.Red, bitmap.GetPixel(50, 50));
+    }
+
+    [Fact]
+    public void ContainerLayer_PaintsAllChildren()
+    {
+        var container = new ContainerLayer();
+        container.Children.Add(MakePicture(SKColors.Red, SKRect.Create(0, 0, 50, 100)));
+        container.Children.Add(MakePicture(SKColors.Blue, SKRect.Create(50, 0, 50, 100)));
+
+        using var bitmap = Renderer.RenderLayerTreeToBitmap(container, Size);
+
+        Assert.Equal(SKColors.Red, bitmap.GetPixel(25, 50));
+        Assert.Equal(SKColors.Blue, bitmap.GetPixel(75, 50));
+    }
+
+    [Fact]
+    public void ClipRectLayer_ClipsToRect()
+    {
+        var clip = new ClipRectLayer(SKRect.Create(0, 0, 50, 100)) { ClipBehavior = Clip.HardEdge };
+        clip.Children.Add(MakePicture(SKColors.Red, SKRect.Create(0, 0, 100, 100)));
+
+        using var bitmap = Renderer.RenderLayerTreeToBitmap(clip, Size);
+
+        Assert.Equal(SKColors.Red, bitmap.GetPixel(25, 50));
+        Assert.Equal(SKColors.Empty, bitmap.GetPixel(75, 50));
+    }
+
+    [Fact]
+    public void ClipRoundRectLayer_ClipsCorners()
+    {
+        var roundRect = new SKRoundRect(SKRect.Create(0, 0, 100, 100), 40, 40);
+        var clip = new ClipRoundRectLayer(roundRect) { ClipBehavior = Clip.HardEdge };
+        clip.Children.Add(MakePicture(SKColors.Red, SKRect.Create(0, 0, 100, 100)));
+
+        using var bitmap = Renderer.RenderLayerTreeToBitmap(clip, Size);
+
+        Assert.Equal(SKColors.Red, bitmap.GetPixel(50, 50));
+        Assert.Equal(SKColors.Empty, bitmap.GetPixel(2, 2));
+    }
+
+    [Fact]
+    public void ClipPathLayer_ClipsToPath()
+    {
+        using var path = new SKPath();
+        path.AddRect(SKRect.Create(0, 0, 50, 100));
+        var clip = new ClipPathLayer(path) { ClipBehavior = Clip.HardEdge };
+        clip.Children.Add(MakePicture(SKColors.Red, SKRect.Create(0, 0, 100, 100)));
+
+        using var bitmap = Renderer.RenderLayerTreeToBitmap(clip, Size);
+
+        Assert.Equal(SKColors.Red, bitmap.GetPixel(25, 50));
+        Assert.Equal(SKColors.Empty, bitmap.GetPixel(75, 50));
+    }
+
+    [Fact]
+    public void OpacityLayer_AppliesAlpha()
+    {
+        var opacity = new OpacityLayer { Alpha = 128 };
+        opacity.Children.Add(MakePicture(SKColors.Red, SKRect.Create(0, 0, 100, 100)));
+
+        using var bitmap = Renderer.RenderLayerTreeToBitmap(opacity, Size);
+        var pixel = bitmap.GetPixel(50, 50);
+
+        Assert.InRange(pixel.Alpha, 120, 136);
+        Assert.True(pixel.Red > 0);
+    }
+
+    [Fact]
+    public void TransformLayer_TranslatesChildren()
+    {
+        var transform = new TransformLayer { Transform = SKMatrix.CreateTranslation(50, 50) };
+        transform.Children.Add(MakePicture(SKColors.Blue, SKRect.Create(0, 0, 10, 10)));
+
+        using var bitmap = Renderer.RenderLayerTreeToBitmap(transform, Size);
+
+        Assert.Equal(SKColors.Blue, bitmap.GetPixel(55, 55));
+        Assert.Equal(SKColors.Empty, bitmap.GetPixel(5, 5));
+    }
+}


### PR DESCRIPTION
## Summary

- **Widget/Elementシステムの実装**: `RenderPipeline` にダーティノード管理と `OnNeedVisualUpdate` コールバックを追加し、Widget ツリーから描画要求に対応
- **WidgetBinding**: Widget → RenderObject → レンダースレッドの接続を一元管理するクラスを新設
- **EventDispatcher リファクタリング**: 抽象クラスに再設計し `VRSystemEventDispatcher` に分離
- **TaskRunner リネーム**: `ThreadRunner`/`RenderThreadRunner` → `TaskRunner`/`RenderTaskRunner`
- **Clip系・ColoredBoxウィジェット**: スタブ実装を `SingleChildRenderObjectWidget` ベースに置き換え
- **ImageRenderer テスト**: `PictureLayer` / `ContainerLayer` / `ClipRectLayer` / `ClipRoundRectLayer` / `ClipPathLayer` / `OpacityLayer` / `TransformLayer` の描画結果をピクセル検証するテストを `FloatSoda.Common.Test` に追加（テストプロジェクトとソースプロジェクトの 1:1 対応方針）
- **ジオメトリテスト**: `BoxConstraints` / `Alignment` / `BorderRadius` のユニットテストを追加

## Test plan

- [ ] `dotnet test tests/FloatSoda.Common.Test` — Layer テスト 7 件 pass
- [ ] `dotnet test tests/FloatSoda.Test` — RenderObject / Widget テスト pass
- [ ] `dotnet build` — ビルドエラーなし
- [ ] サンプルアプリ (`FloatSoda.Samples.OverlayApp`) が SteamVR 環境で起動・描画できること

## Reviewer notes

- `ClipRectLayer.Layout()` / `ClipRoundRectLayer.Layout()` に未対応の `Canvas.Restore()` 呼び出しが残っており、`RenderLayerTreeToBitmap` では `Layout()` を呼ばないため現時点では影響なし
- Widget/Element ツリーは `StatelessWidget.Build()` がフレームワークから呼ばれる部分が未完成（WIP）

🤖 Generated with [Claude Code](https://claude.com/claude-code)