### PR TITLE
docs: CONTRIBUTING.mdを追加

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,102 @@
+# Contributing to FloatSoda
+
+FloatSoda は現在 **v0.0.0 Alpha / 概念実証(PoC)段階** です。API は予告なく破壊的に変更されることがあります。この点をご理解の上でコントリビューションをお願いします。
+
+---
+
+## 開発環境のセットアップ
+
+- .NET 10 / C# 14 SDK
+- SteamVR(サンプルアプリを実行する場合のみ必須)
+
+```bash
+# ソリューション全体のビルド
+dotnet build
+
+# 全テストの実行
+dotnet test
+
+# サンプルアプリの起動(SteamVRを起動してから)
+dotnet run --project samples/FloatSoda.Samples.OverlayApp
+```
+
+---
+
+## ブランチ・PRフロー
+
+- `main` へは直接pushせず、必ずPR経由でマージしてください。
+- ブランチ名は `feature/xxx`、`fix/xxx` のように用途が分かる名前を付けてください。
+- PRを出す前に、CI(`.github/workflows/ci.yml`)と同じ手順をローカルで実行し、パスすることを確認してください。
+
+```bash
+dotnet build --configuration Release
+dotnet test tests/FloatSoda.Common.Test --configuration Release --no-build
+dotnet test tests/FloatSoda.Test --configuration Release --no-build
+```
+
+バグ報告・機能要望は `.github/ISSUE_TEMPLATE/` のテンプレートを使って Issue を立ててください。
+
+---
+
+## テスト方針
+
+テストは xunit を使用しています。
+
+- `tests/FloatSoda.Test` — ジオメトリ型、RenderObject、Widget のテスト
+- `tests/FloatSoda.Common.Test` — Layer ツリーのテスト
+
+追加する機能に応じて、対応するテストプロジェクトにテストを追加してください。
+
+```bash
+# 特定のテストのみ実行する例
+dotnet test tests/FloatSoda.Test --filter "FullyQualifiedName~AlignmentTest.TopLeft"
+```
+
+---
+
+## コーディング規約
+
+API設計の詳細な規約は **[docs/APIDesign.md](docs/APIDesign.md)** を参照してください。要点のみ挙げると:
+
+- コンストラクタ引数は使わず、`init` プロパティのみで構成する(オブジェクト初期化子ファースト)
+- 単一の子は `Child`、複数の子は `Children`(`IList<Widget>`)
+- ジオメトリ型は `readonly record struct`、Context/Theme等は `record`
+- `public` プロパティには XML ドキュメントコメントを付与する
+- イベントハンドラは `Action?` / `Action<T>?` / `Func<Task>?` で `On` プレフィックスを付ける
+- スタイル属性はコンポーネント本体ではなく別の `*Style` record に分離する
+
+---
+
+## 受け入れ範囲
+
+現段階のFloatSodaは、Flutter の `widgets/basic.dart` に相当する **プリミティブ層のウィジェット**(単一の RenderObject への薄いラッパーで、状態やビジネスロジックを持たないもの)のみをコアに受け入れます。
+
+- **対象内の例**: レイアウト系(`Align`, `SizedBox`, `Row`/`Column`, `Padding` 等)、単純な描画・クリップ系ウィジェット
+- **対象外(PRをリジェクトする例)**: `Button` や `Card` のような装飾済み・複合ウィジェット、Material/Cupertino 相当のスタイル付きコンポーネント、ビジネスロジックを含むウィジェット
+
+コアが肥大化すると RenderObject / Layer / Widget-Element の三層アーキテクチャの一貫性を保てなくなるための制約です。このようなウィジェットのコントリビューションは、コア以外の別パッケージやユーザーランドでの実装を検討してください。
+
+---
+
+## アーキテクチャを理解する
+
+FloatSoda は RenderObject ツリー / Layer ツリー / Widget-Element ツリーの三層構造を持ちます。コードを読み始める前に **[docs/Home.md](docs/Home.md)** から目を通すことを推奨します。
+
+特に Widget/Element 層は `StatelessWidget` のみ実装済みで、`StatefulWidget` / `InheritedWidget` / `MultiChildRenderObjectElement.PerformRebuild()`(子リストの差分更新)は未実装(`NotImplementedException`)です。これらの領域に貢献する場合は、事前に設計方針を Issue 等ですり合わせることを推奨します。
+
+---
+
+## ドキュメントを更新する場合の注意
+
+`docs/*.md` は `.github/workflows/sync-wiki.yml` によって GitHub Wiki に自動同期されます。**Wiki側を直接編集しても同期時に上書きされる**ため、ドキュメントの変更は必ず `docs/` 配下のファイルに対して行ってください。
+
+---
+
+## PRを出す前のチェックリスト
+
+- [ ] `dotnet build` が通る
+- [ ] 該当するテストプロジェクトにテストを追加・更新した
+- [ ] `dotnet test` が通る
+- [ ] 追加した `public` プロパティに XML ドキュメントコメントを付けた
+- [ ] Wiki同期対象の `docs/*.md` を直接編集した(Wiki側は編集していない)
+- [ ] プリミティブ層(basics.dart相当)を超える複合ウィジェットを追加していない

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1,0 +1,103 @@
+# Third-Party Notices
+
+FloatSoda's Widget/Element API design (declarative UI, immutable widget composition,
+tree-based composition, naming conventions such as `MainAxisAlignment` /
+`CrossAxisAlignment`) is inspired by [Flutter](https://flutter.dev). No Flutter source
+code is included in this repository, but the following license is reproduced in
+acknowledgement of that design influence.
+
+## Flutter
+
+```
+Copyright 2014 The Flutter Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+    * Neither the name of Google Inc. nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+```
+
+## OpenVR SDK
+
+`src/FloatSoda.OVR/openvr_api.cs` contains the auto-generated C# interop bindings from
+Valve's [OpenVR SDK](https://github.com/ValveSoftware/openvr), included in this
+repository unmodified.
+
+```
+Copyright (c) 2015, Valve Corporation
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, are
+permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of
+   conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice, this list
+   of conditions and the following disclaimer in the documentation and/or other
+   materials provided with the distribution.
+3. Neither the name of the copyright holder nor the names of its contributors may be
+   used to endorse or promote products derived from this software without specific
+   prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+```
+
+## OVRSharp
+
+The high-level OpenVR wrapper design in `src/FloatSoda.OVR` (e.g. `Application`,
+`Overlay`, and the `Exceptions` hierarchy rooted in `OpenVRSystemException`) is
+inspired by [OVRSharp](https://github.com/OVRTools/OVRSharp). No OVRSharp source code
+is included in this repository, but the following license is reproduced in
+acknowledgement of that design influence.
+
+```
+MIT License
+
+Copyright 2020-2021 TJ Horner
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```

--- a/docs/APIDesign.md
+++ b/docs/APIDesign.md
@@ -175,7 +175,7 @@ if (Child != null) context.PaintChild(Child, offset);
 すべてのプロパティは原則として `init` アクセサを使い、構築後の変更を不可にします。状態変化はフレームワークの状態管理レイヤーに委ねてください。
 
 ```csharp
-public class Text : Widget
+public record Text : Widget
 {
     public string Content { get; init; } = string.Empty;
     public double FontSize { get; init; } = 14;
@@ -192,7 +192,7 @@ public class Text : Widget
 - 必須プロパティは `required` キーワードで明示する
 
 ```csharp
-public class Image : Widget
+public record Image : Widget
 {
     public required string Src { get; init; }   // 必須
     public string? Alt { get; init; }           // 省略可


### PR DESCRIPTION
## Summary
- コントリビューター向けの `CONTRIBUTING.md` を新規追加
- セットアップ手順、PR/ブランチフロー、テスト方針、コーディング規約(docs/APIDesign.md参照)、Wiki自動同期の注意点をまとめた
- 「受け入れ範囲」節を追加: Flutterの`widgets/basic.dart`相当のプリミティブ層ウィジェット(単一RenderObjectへの薄いラッパー)のみをコアで受け入れ、Button/Cardのような装飾済み・複合ウィジェットはPRをリジェクトする方針を明記

## Test plan
- [x] ドキュメントのみの変更のためビルド・テストへの影響なし