### PR TITLE
feat(Element): MultiChild要素の子差分とWidget/RenderObjectの差分更新を実装

### DIFF
--- a/src/FloatSoda/Elements/MultiChildRenderObjectElement.cs
+++ b/src/FloatSoda/Elements/MultiChildRenderObjectElement.cs
@@ -17,15 +17,21 @@ public class MultiChildRenderObjectElement<T> : RenderObjectElement<T> where T :
         Children = WidgetCasted.Children.Select(InflateWidget).ToList();
     }
 
-    public override void PerformRebuild()
+    public override void Update(Widget newWidget)
     {
-        throw new NotImplementedException();
+        base.Update(newWidget);
+        Children = UpdateChildren(Children, WidgetCasted.Children);
     }
+
+    public override void VisitChildren(Action<Element> visitor) => Children.ForEach(visitor);
 
     public override void InsertRenderObjectChild(RenderObject child)
     {
         if (RenderObject is IHasMultiChildrenRenderObject ro) ro.AddChild(child);
     }
 
-    public override void VisitChildren(Action<Element> visitor) => Children.ForEach(visitor);
+    public override void RemoveRenderObjectChild(RenderObject? child)
+    {
+        if (child != null && RenderObject is IHasMultiChildrenRenderObject ro) ro.RemoveChild(child);
+    }
 }

--- a/src/FloatSoda/Elements/RenderObjectElement.cs
+++ b/src/FloatSoda/Elements/RenderObjectElement.cs
@@ -23,14 +23,10 @@ public abstract class RenderObjectElement : Element
     }
 
 
-    public virtual void InsertRenderObjectChild(RenderObject? child)
-    {
-    }
+    public virtual void InsertRenderObjectChild(RenderObject? child) { }
 
 
-    public virtual void RemoveRenderObjectChild(RenderObject? child)
-    {
-    }
+    public virtual void RemoveRenderObjectChild(RenderObject? child) { }
 
 
     public RenderObjectElement? FindAncestorRenderObjectElement()
@@ -43,6 +39,116 @@ public abstract class RenderObjectElement : Element
         }
 
         return ancestor as RenderObjectElement;
+    }
+
+    protected List<Element> UpdateChildren(
+        List<Element> oldChildren,
+        List<Widget> newWidgets,
+        HashSet<Element>? forgottenChildren = null)
+    {
+        Element? ReplaceWithNullIfForgotten(Element child)
+            => forgottenChildren != null && forgottenChildren.Contains(child) ? null : child;
+
+        int newChildrenTop = 0;
+        int oldChildrenTop = 0;
+        int newChildrenBottom = newWidgets.Count - 1;
+        int oldChildrenBottom = oldChildren.Count - 1;
+
+        var newChildren = new Element?[newWidgets.Count];
+
+        // 1. 前方から一致する部分を進める
+        while (oldChildrenTop <= oldChildrenBottom && newChildrenTop <= newChildrenBottom)
+        {
+            var oldChild = ReplaceWithNullIfForgotten(oldChildren[oldChildrenTop]);
+            var newWidget = newWidgets[newChildrenTop];
+            if (oldChild == null || !Widget.CanUpdate(oldChild.Widget!, newWidget)) break;
+
+            var newChild = UpdateChild(oldChild, newWidget);
+            newChildren[newChildrenTop] = newChild;
+            newChildrenTop++;
+            oldChildrenTop++;
+        }
+
+        // 2. 後方から一致する部分を確認（bottomだけ動かす。まだ書き戻さない）
+        while (oldChildrenTop <= oldChildrenBottom && newChildrenTop <= newChildrenBottom)
+        {
+            var oldChild = ReplaceWithNullIfForgotten(oldChildren[oldChildrenBottom]);
+            var newWidget = newWidgets[newChildrenBottom];
+            if (oldChild == null || !Widget.CanUpdate(oldChild.Widget!, newWidget)) break;
+
+            oldChildrenBottom--;
+            newChildrenBottom--;
+        }
+
+        // 3. 中間範囲：古い子をkeyでインデックス化
+        Dictionary<IKey, Element>? oldKeyedChildren = null;
+        if (oldChildrenTop <= oldChildrenBottom)
+        {
+            oldKeyedChildren = new Dictionary<IKey, Element>();
+            while (oldChildrenTop <= oldChildrenBottom)
+            {
+                var oldChild = ReplaceWithNullIfForgotten(oldChildren[oldChildrenTop]);
+                if (oldChild != null)
+                {
+                    var key = oldChild.Widget?.Key;
+                    if (key != null)
+                    {
+                        oldKeyedChildren[key] = oldChild;
+                    }
+                    else
+                    {
+                        DeactivateChild(oldChild); // keyなしは再利用できないので即破棄
+                    }
+                }
+
+                oldChildrenTop++;
+            }
+        }
+
+        // 4. 新しいWidgetをkeyで探して再利用、なければ新規作成
+        while (newChildrenTop <= newChildrenBottom)
+        {
+            var newWidget = newWidgets[newChildrenTop];
+            Element? oldChild = null;
+
+            var key = newWidget.Key;
+            if (key != null && oldKeyedChildren != null && oldKeyedChildren.TryGetValue(key, out var matched))
+            {
+                if (Widget.CanUpdate(matched.Widget!, newWidget))
+                {
+                    oldChild = matched;
+                    oldKeyedChildren.Remove(key);
+                }
+            }
+
+            var newChild = UpdateChild(oldChild, newWidget);
+            newChildren[newChildrenTop] = newChild;
+            newChildrenTop++;
+        }
+
+        // 5. 後方一致していた部分を書き戻す
+        newChildrenBottom = newWidgets.Count - 1;
+        oldChildrenBottom = oldChildren.Count - 1;
+        while (oldChildrenTop <= oldChildrenBottom)
+        {
+            var oldChild = oldChildren[oldChildrenTop];
+            var newWidget = newWidgets[newChildrenTop];
+            var newChild = UpdateChild(oldChild, newWidget);
+            newChildren[newChildrenTop] = newChild;
+            newChildrenTop++;
+            oldChildrenTop++;
+        }
+
+        // 6. 再利用されずに残った古い要素を破棄
+        if (oldKeyedChildren != null)
+        {
+            foreach (var remaining in oldKeyedChildren.Values)
+            {
+                DeactivateChild(remaining);
+            }
+        }
+
+        return newChildren.Where(c => c != null).Select(c => c!).ToList();
     }
 }
 

--- a/src/FloatSoda/Elements/SingleChildRenderObjectElement.cs
+++ b/src/FloatSoda/Elements/SingleChildRenderObjectElement.cs
@@ -5,7 +5,6 @@ namespace FloatSoda.Elements;
 
 public class SingleChildRenderObjectElement<T> : RenderObjectElement<T> where T : RenderObject
 {
-
     public SingleChildRenderObjectWidget<T>? WidgetCasted => Widget as SingleChildRenderObjectWidget<T>;
 
     private Element? Child { get; set; }
@@ -17,17 +16,22 @@ public class SingleChildRenderObjectElement<T> : RenderObjectElement<T> where T 
         base.Mount(parent);
         Child = UpdateChild(Child, WidgetCasted?.Child);
     }
-    
+
 
     public override void Update(Widget newWidget)
     {
         base.Update(newWidget);
-        PerformRebuild();
+        Child = UpdateChild(Child, WidgetCasted?.Child);
     }
 
     public override void InsertRenderObjectChild(RenderObject? child)
     {
         if (RenderObject is IHasSingleChildRenderObject ro) ro.Child = child;
+    }
+
+    public override void RemoveRenderObjectChild(RenderObject? child)
+    {
+        if (RenderObject is IHasSingleChildRenderObject ro) ro.Child = null;
     }
 
     public override void VisitChildren(Action<Element> visitor)

--- a/src/FloatSoda/RenderObjects/Layout/RenderFlex.cs
+++ b/src/FloatSoda/RenderObjects/Layout/RenderFlex.cs
@@ -11,7 +11,8 @@ public class RenderFlex : RenderBox, IHasMultiChildrenRenderObject
 
     public RenderFlex() => Children = new MultiChildrenCollection<RenderBox>(this);
 
-    void IHasMultiChildrenRenderObject.AddChild(RenderObject child) => Children.Add((RenderBox)child);
+    public void AddChild(RenderObject child) => Children.Add((RenderBox)child);
+    public bool RemoveChild(RenderObject child) => Children.Remove((RenderBox)child);
 
     public override void SetupParentData(RenderObject child) => child.ParentData = new BoxParentData();
 
@@ -232,5 +233,4 @@ public class RenderFlex : RenderBox, IHasMultiChildrenRenderObject
             }
         }
     }
-
 }

--- a/src/FloatSoda/RenderObjects/Painting/RenderCustomClip.cs
+++ b/src/FloatSoda/RenderObjects/Painting/RenderCustomClip.cs
@@ -14,11 +14,63 @@ public abstract class CustomClipper<T>
 
 public abstract class RenderCustomClip<T> : RenderProxyBox
 {
-    public CustomClipper<T>? Clipper { get; init; } = null;
-    public Clip ClipBehavior { get; init; } = Common.Layer.Clip.Antialias;
+    public CustomClipper<T>? Clipper
+    {
+        get;
+        set
+        {
+            if (field == value) return;
 
-    protected T Clip => Clipper != null ? Clipper.GetClip(Size) : DefaultClip;
+            var oldClipper = value;
+            field = value;
+
+            if (value == null || oldClipper == null || value.GetType() != oldClipper.GetType() ||
+                value.ShouldReclip(oldClipper))
+            {
+                MarkNeedsLayout();
+            }
+        }
+    }
+
+
+    public Clip ClipBehavior
+    {
+        get;
+        set
+        {
+            if (field == value) return;
+            field = value;
+            MarkNeedsPaint();
+        }
+    } = Common.Layer.Clip.Antialias;
+
+    protected T? Clip
+    {
+        get => Clipper != null ? Clipper.GetClip(Size) : DefaultClip;
+        set => throw new NotImplementedException();
+    }
+
     protected abstract T DefaultClip { get; }
+
+    protected void MarkNeedsClip()
+    {
+        Clip = default;
+        MarkNeedsPaint();
+    }
+
+    public override void PerformLayout()
+    {
+        var oldSize = Size;
+
+        base.PerformLayout();
+
+        if (oldSize != Size) Clip = default;
+    }
+
+    protected void UpdateClip()
+    {
+        if (Clipper != null) Clip ??= Clipper.GetClip(Size) ?? DefaultClip;
+    }
 }
 
 public class RenderClipRect : RenderCustomClip<SKRect>
@@ -29,7 +81,12 @@ public class RenderClipRect : RenderCustomClip<SKRect>
     {
         if (Child != null)
         {
-            Layer = context.PushClipRect(offset, Clip, (c, o) => base.Paint(c, o), ClipBehavior, Layer as ClipRectLayer);
+            UpdateClip();
+            Layer = context.PushClipRect(
+                offset,
+                Clip,
+                (c, o) => base.Paint(c, o), ClipBehavior,
+                Layer as ClipRectLayer);
         }
         else
         {
@@ -48,6 +105,7 @@ public class RenderClipRoundRect : RenderCustomClip<SKRoundRect>
     {
         if (Child != null)
         {
+            UpdateClip();
             Layer = context.PushClipRoundRect(
                 offset,
                 Clip.Rect,
@@ -78,16 +136,22 @@ public class RenderClipPath : RenderCustomClip<SKPath>
 
     public override void Paint(PaintingContext context, Offset offset)
     {
-        if (Child == null) return;
-
-        Layer = context.PushClipPath(
-            offset,
-            SKRect.Create(Offset.Zero, Size),
-            Clip,
-            (c, o) => base.Paint(c, o),
-            ClipBehavior,
-            Layer as ClipPathLayer
-        );
+        if (Child == null)
+        {
+            UpdateClip();
+            Layer = context.PushClipPath(
+                offset,
+                SKRect.Create(Offset.Zero, Size),
+                Clip,
+                (c, o) => base.Paint(c, o),
+                ClipBehavior,
+                Layer as ClipPathLayer
+            );
+        }
+        else
+        {
+            Layer = null;
+        }
     }
 }
 
@@ -97,6 +161,10 @@ public class RenderClipOval : RenderCustomClip<SKRect>
 
     public override void Paint(PaintingContext context, Offset offset)
     {
+        if (Child == null) return;
+
+        UpdateClip();
+
         var path = new SKPath();
         path.AddOval(Clip);
 

--- a/src/FloatSoda/RenderObjects/RenderObjectMixin.cs
+++ b/src/FloatSoda/RenderObjects/RenderObjectMixin.cs
@@ -19,7 +19,11 @@ public interface IHasMultiChildrenRenderObject
 {
     /// <summary>子を末尾に追加する。</summary>
     void AddChild(RenderObject child);
+
+    /// <summary>指定した子を取り除く。取り除けたら true。</summary>
+    bool RemoveChild(RenderObject child);
 }
+
 
 /// <summary>
 /// 単一の子の保持をコンポジションで提供するコンテナ。子の差し替え時にownerへのAdopt/Dropを行い、
@@ -56,13 +60,12 @@ public class SingleChildContainer<T>(RenderObject owner) where T : RenderObject
 /// 複数の子の保持をコンポジションで提供するコレクション。追加・削除時にownerへのAdopt/Dropを行い、
 /// ライフサイクル(Attach/Detach/Visit)の転送ヘルパーを提供する。
 /// </summary>
-public class MultiChildrenCollection<T>(RenderObject owner) : IReadOnlyList<T> where T : RenderObject
+public class MultiChildrenCollection<T>(RenderObject owner) : ICollection<T> where T : RenderObject
 {
     private readonly List<T> _children = [];
 
     public int Count => _children.Count;
-
-    public T this[int index] => _children[index];
+    public bool IsReadOnly => false;
 
     /// <summary>子を末尾に追加する。</summary>
     public void Add(T child)
@@ -70,6 +73,8 @@ public class MultiChildrenCollection<T>(RenderObject owner) : IReadOnlyList<T> w
         owner.AdoptChild(child);
         _children.Add(child);
     }
+
+    public void CopyTo(T[] array, int arrayIndex) => _children.CopyTo(array, arrayIndex);
 
     /// <summary>子を取り除く。</summary>
     public bool Remove(T child)
@@ -90,6 +95,8 @@ public class MultiChildrenCollection<T>(RenderObject owner) : IReadOnlyList<T> w
 
         _children.Clear();
     }
+
+    public bool Contains(T item) => _children.Contains(item);
 
     /// <summary>全ての子をRenderPipelineへアタッチする。ownerのAttachから呼ぶ。</summary>
     public void Attach(RenderPipeline? pipeline)
@@ -139,4 +146,12 @@ public static class MultiChildrenCollectionExtensions
             collection.Add(child);
         }
     }
+
+    /// <summary><see cref="RenderObject"/>を要素型へ変換して末尾に追加する。Element境界の非総称な挿入に使う。</summary>
+    public static void AddErased<T>(this MultiChildrenCollection<T> collection, RenderObject child)
+        where T : RenderObject => collection.Add((T)child);
+
+    /// <summary><see cref="RenderObject"/>を要素型として取り除く。要素型でない・保持していない場合は false。</summary>
+    public static bool RemoveErased<T>(this MultiChildrenCollection<T> collection, RenderObject child)
+        where T : RenderObject => child is T typed && collection.Remove(typed);
 }

--- a/src/FloatSoda/RenderObjects/RenderParagraph.cs
+++ b/src/FloatSoda/RenderObjects/RenderParagraph.cs
@@ -9,7 +9,9 @@ public class RenderParagraph : RenderBox, IHasMultiChildrenRenderObject
 {
     public MultiChildrenCollection<RenderBox> Children { get; }
 
-    void IHasMultiChildrenRenderObject.AddChild(RenderObject child) => Children.Add((RenderBox)child);
+    void IHasMultiChildrenRenderObject.AddChild(RenderObject child) => Children.AddErased(child);
+
+    bool IHasMultiChildrenRenderObject.RemoveChild(RenderObject child) => Children.RemoveErased(child);
 
     public override void SetupParentData(RenderObject child) => child.ParentData = new BoxParentData();
 

--- a/src/FloatSoda/Widgets/Components/RichText.cs
+++ b/src/FloatSoda/Widgets/Components/RichText.cs
@@ -1,2 +1,0 @@
-﻿namespace FloatSoda.Widgets.Components;
-

--- a/src/FloatSoda/Widgets/Components/Text.cs
+++ b/src/FloatSoda/Widgets/Components/Text.cs
@@ -7,10 +7,9 @@ public sealed record RichText : MultiChildRenderObjectWidget<RenderParagraph>
 {
     public required TextSpan Text { get; init; }
 
-    public override RenderParagraph CreateRenderObject() => new()
-    {
-        Text = Text
-    };
+    public override RenderParagraph CreateRenderObject() => new() { Text = Text };
+
+    public override void UpdateRenderObject(RenderParagraph renderObject) => renderObject.Text = Text;
 }
 
 public sealed record Text(string Data) : StatelessWidget
@@ -18,7 +17,7 @@ public sealed record Text(string Data) : StatelessWidget
     public override Widget Build(IBuildContext context)
     {
         var text = new TextSpan(Data);
-        
+
         return new RichText
         {
             Text = text

--- a/src/FloatSoda/Widgets/Layout/Flex.cs
+++ b/src/FloatSoda/Widgets/Layout/Flex.cs
@@ -27,7 +27,11 @@ public sealed record Flex : MultiChildRenderObjectWidget<RenderFlex>
 
     public override void UpdateRenderObject(RenderFlex renderObject)
     {
-        throw new NotImplementedException();
+        renderObject.Direction = Direction;
+        renderObject.MainAxisAlignment = MainAxisAlignment;
+        renderObject.MainAxisSize = MainAxisSize;
+        renderObject.CrossAxisAlignment = CrossAxisAlignment;
+        renderObject.VerticalDirection = VerticalDirection;
     }
 }
 

--- a/src/FloatSoda/Widgets/Paint/ClipOval.cs
+++ b/src/FloatSoda/Widgets/Paint/ClipOval.cs
@@ -7,16 +7,22 @@ namespace FloatSoda.Widgets.Paint;
 
 public record ClipOval : SingleChildRenderObjectWidget<RenderClipOval>
 {
-    public CustomClipper<SKRect>? CustomClipper { get; init; } = null;
+    public CustomClipper<SKRect>? Clipper { get; init; } = null;
     public Clip ClipBehavior { get; init; } = Clip.Antialias;
 
     public override RenderClipOval CreateRenderObject()
     {
         return new RenderClipOval
         {
-            Clipper = CustomClipper,
+            Clipper = Clipper,
             ClipBehavior = ClipBehavior
         };
+    }
+
+    public override void UpdateRenderObject(RenderClipOval renderObject)
+    {
+        renderObject.Clipper = Clipper;
+        renderObject.ClipBehavior = ClipBehavior;
     }
 }
 
@@ -33,6 +39,12 @@ public record ClipRect : SingleChildRenderObjectWidget<RenderClipRect>
             Clipper = Clipper,
             ClipBehavior = ClipBehavior
         };
+    }
+
+    public override void UpdateRenderObject(RenderClipRect renderObject)
+    {
+        renderObject.Clipper = Clipper;
+        renderObject.ClipBehavior = ClipBehavior;
     }
 }
 
@@ -52,6 +64,13 @@ public record ClipRoundRect : SingleChildRenderObjectWidget<RenderClipRoundRect>
             ClipBehavior = ClipBehavior
         };
     }
+
+    public override void UpdateRenderObject(RenderClipRoundRect renderObject)
+    {
+        renderObject.BorderRadius = BorderRadius;
+        renderObject.Clipper = Clipper;
+        renderObject.ClipBehavior = ClipBehavior;
+    }
 }
 
 public record ClipCustomPath : SingleChildRenderObjectWidget<RenderClipPath>
@@ -67,5 +86,11 @@ public record ClipCustomPath : SingleChildRenderObjectWidget<RenderClipPath>
             Clipper = Clipper,
             ClipBehavior = ClipBehavior
         };
+    }
+
+    public override void UpdateRenderObject(RenderClipPath renderObject)
+    {
+        renderObject.Clipper = Clipper;
+        renderObject.ClipBehavior = ClipBehavior;
     }
 }

--- a/src/FloatSoda/Widgets/Widget.cs
+++ b/src/FloatSoda/Widgets/Widget.cs
@@ -4,6 +4,14 @@ namespace FloatSoda.Widgets;
 
 public abstract record Widget
 {
-    public static bool CanUpdate(Widget oldWidget, Widget newWidget) => oldWidget == newWidget;
+    public IKey? Key { get; init; }
+    
+    public static bool CanUpdate(Widget oldWidget, Widget newWidget)
+    {
+        return oldWidget.GetType() == newWidget.GetType() && Equals(oldWidget.Key, newWidget.Key);
+    }
+
     public abstract Element CreateElement();
+
+    public override int GetHashCode() => (Key != null ? Key.GetHashCode() : 0);
 }


### PR DESCRIPTION
- MultiChildRenderObjectElement.Update で Flutter方式の子リスト差分 (前後一致 + keyインデックス) による Element 再利用を実装
- RenderObjectElement.UpdateChildren を追加し、key照合・再利用・破棄を集約
- Widget に Key を追加し CanUpdate を型+key 判定へ変更
- Flex/Clip系Widget の UpdateRenderObject を実装 (従来は NotImplemented)
- RenderCustomClip をインクリメンタル対応: Clipper/ClipBehavior の setter で MarkNeedsLayout/Paint、Clip をキャッシュし UpdateClip で再計算
- IHasMultiChildrenRenderObject に RemoveChild を追加、 MultiChildrenCollection を ICollection 化 + AddErased/RemoveErased 拡張