### PR TITLE
feat(Element): Widget差分更新とStatefulElement<T>ライフサイクルを実装

### DIFF
--- a/samples/FloatSoda.Samples.OverlayApp/Program.cs
+++ b/samples/FloatSoda.Samples.OverlayApp/Program.cs
@@ -1,31 +1,19 @@
 ﻿using FloatSoda;
 using FloatSoda.OVR.Overlay;
 using FloatSoda.Samples.OverlayApp;
-using FloatSoda.Widgets;
-using FloatSoda.Widgets.Layout;
-using FloatSoda.Widgets.Paint;
 using SkiaSharp;
 
 var builder = FloatSodaAppBuilder.CreateDefault();
 
 using var app = builder.Build();
 
-
-Widget floatSodaDashboard = new Align
-{
-    Child = new SizedBox
-    {
-        Width = 100,
-        Height = 100,
-        Child = new ColoredBox()
-        {
-            Color = SKColors.Tomato
-        }
-    }
-};
+var size = new SKSizeI(1000, 1000);
 
 
-app.CreateDashboardOverlay("FloatSodaDashboard", floatSodaDashboard, 1000, 1000);
-// app.CreateTrackingOverlay("watch", new WatchWidget(), 1000, 1000, TrackedDevice.LeftController);
+app.CreateDashboardOverlay("FloatSodaDashboard", new StackWidget { Width = size.Width, Height = size.Height },
+    size.Width, size.Width);
+
+app.CreateDashboardOverlay("WatchDashBoard", new WatchWidget(), size.Width, size.Height);
+app.CreateTrackingOverlay("Left Hand", new WatchWidget(), size.Width, size.Height, TrackedDevice.LeftController);
 
 app.Run();

--- a/samples/FloatSoda.Samples.OverlayApp/StackWidget.cs
+++ b/samples/FloatSoda.Samples.OverlayApp/StackWidget.cs
@@ -1,0 +1,70 @@
+﻿using FloatSoda.Elements;
+using FloatSoda.Geometrics;
+using FloatSoda.Widgets;
+using FloatSoda.Widgets.Layout;
+using FloatSoda.Widgets.Paint;
+using SkiaSharp;
+
+namespace FloatSoda.Samples.OverlayApp;
+
+public record StackWidget : StatelessWidget
+{
+    public required double Width { get; init; }
+    public required double Height { get; init; }
+
+    public override Widget Build(IBuildContext context)
+
+    {
+        return new Align
+        {
+            Alignment = Alignment.Center,
+            Child = new SizedBox
+            {
+                Width = Width,
+                Height = Height,
+                Child = new ColoredBox
+                {
+                    Color = SKColors.WhiteSmoke,
+                    Child = new Flex
+                    {
+                        MainAxisAlignment = MainAxisAlignment.Center,
+                        CrossAxisAlignment = CrossAxisAlignment.Center,
+                        Children =
+                        {
+                            new ClipRoundRect
+                            {
+                                BorderRadius = BorderRadius.Circular(20),
+                                Child = new SizedBox
+                                {
+                                    Child = new ColoredBox { Color = SKColors.DarkSeaGreen },
+                                    Width = Width / 4,
+                                    Height = Height / 4
+                                }
+                            },
+                            new ClipRoundRect
+                            {
+                                BorderRadius = BorderRadius.Circular(20),
+                                Child = new SizedBox
+                                {
+                                    Child = new ColoredBox { Color = SKColors.Tomato },
+                                    Width = Width / 4,
+                                    Height = Height / 4
+                                },
+                            },
+                            new ClipRoundRect
+                            {
+                                BorderRadius = BorderRadius.Circular(20),
+                                Child = new SizedBox
+                                {
+                                    Child = new ColoredBox { Color = SKColors.CornflowerBlue },
+                                    Width = Width / 4,
+                                    Height = Height / 4
+                                },
+                            },
+                        }
+                    }
+                }
+            }
+        };
+    }
+}

--- a/samples/FloatSoda.Samples.OverlayApp/WatchWidget.cs
+++ b/samples/FloatSoda.Samples.OverlayApp/WatchWidget.cs
@@ -39,15 +39,22 @@ public record WatchState : State<WatchWidget>
                 Height = 500,
                 Child = new ClipRoundRect
                 {
-                    BorderRadius = BorderRadius.All(Radius.Circular(20)),
+                    BorderRadius = BorderRadius.All(Radius.Circular(200)),
                     Child = new ColoredBox
                     {
-                        Color = SKColors.PowderBlue,
-                        Child = new RichText
+                        Color = SKColors.WhiteSmoke,
+                        Child = new Center()
                         {
-                            Text = new TextSpan(_time)
+                            Child = new RichText
                             {
-                                Style = new Style { TextColor = SKColor.FromHsv(0, 0, 10) }
+                                Text = new TextSpan(_time)
+                                {
+                                    Style = new Style
+                                    {
+                                        TextColor = SKColor.FromHsv(0, 0, 10),
+                                        FontSize = 100
+                                    }
+                                }
                             }
                         }
                     }

--- a/src/FloatSoda/Core/WidgetBinding.cs
+++ b/src/FloatSoda/Core/WidgetBinding.cs
@@ -92,8 +92,6 @@ public class WidgetBinding
         if (!NeedsVisualUpdate || Window == null) return;
         NeedsVisualUpdate = false;
 
-        Pipeline?.RenderView.PrepareInitialFrame();
-
         Pipeline?.FlushLayout();
         Pipeline?.FlushPaint();
 

--- a/src/FloatSoda/Elements/ComponentElement.cs
+++ b/src/FloatSoda/Elements/ComponentElement.cs
@@ -30,21 +30,67 @@ public abstract class ComponentElement : Element
     }
 }
 
-public class StatefulElement : ComponentElement
-{
-    public void MarkNeedsBuild()
-    {
-        throw new NotImplementedException();
-    }
-
-
-    public override Widget Build()
-    {
-        throw new NotImplementedException();
-    }
-}
-
 public class StatelessElement : ComponentElement
 {
     public override Widget Build() => ((StatelessWidget)Widget!).Build(this);
+
+    public override void Update(Widget newWidget)
+    {
+        base.Update(newWidget);
+        Dirty = true;
+        Rebuild();
+    }
+}
+
+public class StatefulElement<T> : ComponentElement where T : StatefulWidget<T>
+{
+    public State<T> State => _stateInternal!;
+    private State<T>? _stateInternal = null;
+    private bool _didChangeDependencies = false;
+
+    public override void Mount(Element? parent)
+    {
+        _stateInternal = ((StatefulWidget<T>)Widget!).CreateState();
+        State.Element = this;
+        State.Widget = (T)Widget!;
+        base.Mount(parent);
+    }
+
+    public override void FirstBuild()
+    {
+        State.InitState();
+        State.DidChangeDependencies();
+        base.FirstBuild();
+    }
+
+    public override void PerformRebuild()
+    {
+        if (_didChangeDependencies)
+        {
+            State.DidChangeDependencies();
+            _didChangeDependencies = false;
+        }
+
+        base.PerformRebuild();
+    }
+
+
+    public override Widget Build() => State.Build(this);
+
+    public override void Update(Widget newWidget)
+    {
+        base.Update(newWidget);
+
+        var oldWidget = State.Widget!;
+        Dirty = true;
+        State.Widget = (T)Widget!;
+        State.DidUpdateWidget(oldWidget);
+        Rebuild();
+    }
+
+    public override void DidChangeDependencies()
+    {
+        base.DidChangeDependencies();
+        _didChangeDependencies = true;
+    }
 }

--- a/src/FloatSoda/Elements/Element.cs
+++ b/src/FloatSoda/Elements/Element.cs
@@ -5,7 +5,7 @@ namespace FloatSoda.Elements;
 
 public abstract class Element : IBuildContext, IComparable<Element>
 {
-    public virtual Widget? Widget { get; set; }
+    public Widget? Widget { get; set; }
 
     public Element? Parent { get; set; }
 
@@ -40,9 +40,7 @@ public abstract class Element : IBuildContext, IComparable<Element>
     public bool InDirtyList { get; set; }
     public bool Dirty { get; set; }
 
-    public virtual void VisitChildren(Action<Element> visitor)
-    {
-    }
+    public virtual void VisitChildren(Action<Element> visitor) { }
 
     public virtual void Mount(Element? parent)
     {
@@ -99,9 +97,7 @@ public abstract class Element : IBuildContext, IComparable<Element>
         return newChild;
     }
 
-    public virtual void AttachRenderObject()
-    {
-    }
+    public virtual void AttachRenderObject() { }
 
     public virtual void DetachRenderObject()
     {
@@ -114,7 +110,7 @@ public abstract class Element : IBuildContext, IComparable<Element>
         child.DetachRenderObject();
     }
 
-    public void DidChangeDependencies() => MarkNeedsBuild();
+    public virtual void DidChangeDependencies() => MarkNeedsBuild();
 
     public void MarkNeedsBuild()
     {

--- a/src/FloatSoda/RenderObjects/Layout/RenderPositionedBox.cs
+++ b/src/FloatSoda/RenderObjects/Layout/RenderPositionedBox.cs
@@ -93,7 +93,7 @@ public class RenderPositionedBox : RenderBox, IHasSingleChildRenderObject
         if (Child == null) return;
 
         var childParentData = Child.ParentData as BoxParentData;
-        Child.Paint(context, offset + (childParentData?.Offset ?? Offset.Zero));
+        context.PaintChild(Child, offset + (childParentData?.Offset ?? Offset.Zero));
     }
 
     public override void Attach(RenderPipeline? owner)

--- a/src/FloatSoda/RenderObjects/Painting/RenderCustomClip.cs
+++ b/src/FloatSoda/RenderObjects/Painting/RenderCustomClip.cs
@@ -21,13 +21,13 @@ public abstract class RenderCustomClip<T> : RenderProxyBox
         {
             if (field == value) return;
 
-            var oldClipper = value;
+            var oldClipper = field;
             field = value;
 
             if (value == null || oldClipper == null || value.GetType() != oldClipper.GetType() ||
                 value.ShouldReclip(oldClipper))
             {
-                MarkNeedsLayout();
+                MarkNeedsClip();
             }
         }
     }
@@ -44,19 +44,11 @@ public abstract class RenderCustomClip<T> : RenderProxyBox
         }
     } = Common.Layer.Clip.Antialias;
 
-    protected T? Clip
-    {
-        get => Clipper != null ? Clipper.GetClip(Size) : DefaultClip;
-        set => throw new NotImplementedException();
-    }
+    protected T Clip => Clipper != null ? Clipper.GetClip(Size) : DefaultClip;
 
     protected abstract T DefaultClip { get; }
 
-    protected void MarkNeedsClip()
-    {
-        Clip = default;
-        MarkNeedsPaint();
-    }
+    protected void MarkNeedsClip() => MarkNeedsPaint();
 
     public override void PerformLayout()
     {
@@ -64,12 +56,7 @@ public abstract class RenderCustomClip<T> : RenderProxyBox
 
         base.PerformLayout();
 
-        if (oldSize != Size) Clip = default;
-    }
-
-    protected void UpdateClip()
-    {
-        if (Clipper != null) Clip ??= Clipper.GetClip(Size) ?? DefaultClip;
+        if (oldSize != Size) MarkNeedsClip();
     }
 }
 
@@ -81,7 +68,6 @@ public class RenderClipRect : RenderCustomClip<SKRect>
     {
         if (Child != null)
         {
-            UpdateClip();
             Layer = context.PushClipRect(
                 offset,
                 Clip,
@@ -105,7 +91,6 @@ public class RenderClipRoundRect : RenderCustomClip<SKRoundRect>
     {
         if (Child != null)
         {
-            UpdateClip();
             Layer = context.PushClipRoundRect(
                 offset,
                 Clip.Rect,
@@ -136,9 +121,8 @@ public class RenderClipPath : RenderCustomClip<SKPath>
 
     public override void Paint(PaintingContext context, Offset offset)
     {
-        if (Child == null)
+        if (Child != null)
         {
-            UpdateClip();
             Layer = context.PushClipPath(
                 offset,
                 SKRect.Create(Offset.Zero, Size),
@@ -162,8 +146,6 @@ public class RenderClipOval : RenderCustomClip<SKRect>
     public override void Paint(PaintingContext context, Offset offset)
     {
         if (Child == null) return;
-
-        UpdateClip();
 
         var path = new SKPath();
         path.AddOval(Clip);

--- a/src/FloatSoda/RenderObjects/RenderImage.cs
+++ b/src/FloatSoda/RenderObjects/RenderImage.cs
@@ -23,6 +23,6 @@ public class RenderImage : RenderProxyBox
     public override void Paint(PaintingContext context, Offset offset)
     {
         context.Canvas.DrawImage(Image, SKRect.Create(offset, Size));
-        Child?.Paint(context, offset);
+        if (Child != null) context.PaintChild(Child, offset);
     }
 }

--- a/src/FloatSoda/RenderObjects/RenderParagraph.cs
+++ b/src/FloatSoda/RenderObjects/RenderParagraph.cs
@@ -38,15 +38,15 @@ public class RenderParagraph : RenderBox, IHasMultiChildrenRenderObject
         {
             if (field == value) return;
             field = value;
-            MarkNeedsPaint();
+            _textPainter.Text = value;
+            MarkNeedsLayout();
         }
     }
 
-    private readonly TextPainter _textPainter;
+    private readonly TextPainter _textPainter = new();
 
     public RenderParagraph()
     {
-        _textPainter = new TextPainter(Text);
         Children = new MultiChildrenCollection<RenderBox>(this);
     }
 
@@ -66,14 +66,14 @@ public record TextSpan(string Text)
     public void Build(TextBlock textBlock, Style defaultStyle) => textBlock.AddText(Text, Style ?? defaultStyle);
 }
 
-public class TextPainter(TextSpan text)
+public class TextPainter
 {
-    public TextSpan Text
+    public TextSpan? Text
     {
         get;
         set
         {
-            if (field.Text == value.Text) return;
+            if (field == value) return;
             field = value;
             MarkNeedsLayout();
         }
@@ -95,7 +95,7 @@ public class TextPainter(TextSpan text)
     private TextBlock CreateTextBlock()
     {
         var textBlock = new TextBlock();
-        text.Build(textBlock, CreateDefaultStyle());
+        Text?.Build(textBlock, CreateDefaultStyle());
         return textBlock;
     }
 

--- a/src/FloatSoda/RenderObjects/RenderView.cs
+++ b/src/FloatSoda/RenderObjects/RenderView.cs
@@ -35,7 +35,10 @@ public class RenderView : RenderObject, IHasSingleChildRenderObject
     public override void PerformLayout() => Child?.Layout(BoxConstraints.Tight(Size));
 
 
-    public override void Paint(PaintingContext context, Offset offset) => Child?.Paint(context, offset);
+    public override void Paint(PaintingContext context, Offset offset)
+    {
+        if (Child != null) context.PaintChild(Child, offset);
+    }
 
     public override void Attach(RenderPipeline? owner)
     {

--- a/src/FloatSoda/Widgets/ComponentWidget.cs
+++ b/src/FloatSoda/Widgets/ComponentWidget.cs
@@ -14,7 +14,7 @@ public abstract record StatelessWidget : Widget
 
 public abstract record StatefulWidget<T> : Widget where T : StatefulWidget<T>
 {
-    public override Element CreateElement() => new StatefulElement
+    public override Element CreateElement() => new StatefulElement<T>
     {
         Widget = this
     };
@@ -24,27 +24,23 @@ public abstract record StatefulWidget<T> : Widget where T : StatefulWidget<T>
 
 public abstract record State<T> where T : StatefulWidget<T>
 {
-    public T? Widget { get; init; }
-    public StatefulElement? Element { get; set; }
+    public T? Widget { get; set; }
+
+
+    public StatefulElement<T>? Element { get; set; }
     public IBuildContext Context => Element!;
 
-    public virtual void InitState()
-    {
-    }
+    public virtual void InitState() { }
 
     protected virtual void SetState(Action action)
     {
         action();
-        Element.MarkNeedsBuild();
+        Element?.MarkNeedsBuild();
     }
 
-    public virtual void DidUpdateWidget(T oldWidget)
-    {
-    }
+    public virtual void DidUpdateWidget(T oldWidget) { }
 
-    protected virtual void DidChangeDependencies()
-    {
-    }
+    public virtual void DidChangeDependencies() { }
 
     public abstract Widget Build(IBuildContext context);
 }


### PR DESCRIPTION
## 概要

Widget/Element ツリーの差分(インクリメンタル)更新を実装するブランチです。BuildOwner による dirty-list リビルド、MultiChild/SingleChild 要素の子差分更新に加え、最終コミットで `StatefulElement<T>` のライフサイクルを実装しました。

## 変更内容

- **BuildOwner による差分ビルド**: dirty な Element を Depth 順にリビルドし、RenderObject の dirty フラグで layout/paint をスキップ
- **子の差分更新**: `MultiChildRenderObjectElement` / `SingleChildRenderObjectElement` の `Update` で子 Element を `UpdateChild` により差し替え・再利用
- **`StatefulElement<T>` の実装**(最終コミット):
  - `StatefulElement` をジェネリック化して `State<T>` と型安全に接続(CS0266 x2 のビルドエラーを解消)
  - `new` による `Widget` プロパティ隠蔽を削除し、基底 `Element.Widget` を `(T)` キャストで利用(`base.Update()` 後に古い Widget が残る不整合も解消)
  - state 生成をコンストラクタから `Mount()` へ移動 — オブジェクト初期化子(`new StatefulElement<T> { Widget = this }`)はコンストラクタの後に実行されるため、旧実装では `Widget` が常に null で NRE になっていた
  - `FirstBuild()` で `State.InitState()` / `DidChangeDependencies()` を初回ビルド前に呼ぶ(Flutter の `_firstBuild` 相当)
- ドキュメント同期、CONTRIBUTING.md、サードパーティ表記の追加

## レビューポイント

- `StatefulElement<T>` の CRTP(`where T : StatefulWidget<T>`)設計: `State<T>.Widget` の型を `T` にするための構成です
- state 生成・`InitState` の呼び出しタイミング(Mount → FirstBuild)が Flutter のライフサイクルと整合しているか

## テスト

- `dotnet build`: エラー 0
- `dotnet test tests/FloatSoda.Test`: 76 件すべて合格(StatefulWidget 専用のテストは未整備)

🤖 Generated with [Claude Code](https://claude.com/claude-code)