### PR TITLE
feat(DX): dotnet watch ホットリロードでWidgetツリーを再構築

### DIFF
--- a/src/FloatSoda/Core/HotReloadHandler.cs
+++ b/src/FloatSoda/Core/HotReloadHandler.cs
@@ -1,33 +1,35 @@
-﻿using System.Reflection.Metadata;
+using System.Reflection.Metadata;
 using FloatSoda.Core;
 
 [assembly: MetadataUpdateHandler(typeof(HotReloadHandler))]
 
 namespace FloatSoda.Core;
 
+/// <summary>
+/// dotnet watch / IDE のホットリロード通知を受け取り、
+/// 稼働中の全<see cref="FloatSoda.FloatSodaApp"/>のWidgetツリー再ビルドをスケジュールする。
+/// 任意スレッドから呼ばれるため、実際の再ビルドはメインループへマーシャリングされる。
+/// </summary>
 public static class HotReloadHandler
 {
     public static void ClearCache(Type[]? updatedTypes)
     {
-        Console.WriteLine("[🥤Float Soda HotReloadHandler] 🗑️Clearing cache");
-
-        if (updatedTypes == null) return;
-
-        foreach (var type in updatedTypes)
-        {
-            Console.WriteLine($"✏️{type.FullName}");
-        }
+        // 現状破棄すべきキャッシュはない（ImageProvider等のキャッシュ導入時にここへ接続する）
+        Console.WriteLine("[🥤FloatSoda HotReload] 🗑️ ClearCache");
     }
 
     public static void UpdateApplication(Type[]? updatedTypes)
     {
-        Console.WriteLine("[🥤Float Soda HotReloadHandler]🔥 application hot reloaded");
+        Console.WriteLine("[🥤FloatSoda HotReload] 🔥 コード差し替えを検知、Widgetツリーを再ビルドします");
 
-        if (updatedTypes == null) return;
-
-        foreach (var type in updatedTypes)
+        if (updatedTypes != null)
         {
-            Console.WriteLine($"{type.FullName} {type.Assembly.GetName().Name}");
+            foreach (var type in updatedTypes)
+            {
+                Console.WriteLine($"  ✏️ {type.FullName}");
+            }
         }
+
+        FloatSoda.FloatSodaApp.ScheduleReassembleAll();
     }
 }

--- a/src/FloatSoda/Core/WidgetBinding.cs
+++ b/src/FloatSoda/Core/WidgetBinding.cs
@@ -82,6 +82,12 @@ public class WidgetBinding
         }
     }
 
+    /// <summary>
+    /// ホットリロード時にWidgetツリー全体を再ビルド対象にする。
+    /// 実際の再ビルドは次の<see cref="DrawFrame"/>のBuildScopeで行われる。
+    /// </summary>
+    public void Reassemble() => RenderViewElement?.Reassemble();
+
     public void DrawFrame()
     {
         if (RenderViewElement != null)

--- a/src/FloatSoda/Elements/Element.cs
+++ b/src/FloatSoda/Elements/Element.cs
@@ -120,6 +120,16 @@ public abstract class Element : IBuildContext, IComparable<Element>
         Owner?.ScheduledBuildFor(this);
     }
 
+    /// <summary>
+    /// ホットリロード時に呼ばれ、このElement以下のサブツリー全体を再ビルド対象にする。
+    /// Widgetのrecord等価による差分スキップに関わらず、全ComponentElementのBuild()が再実行される。
+    /// </summary>
+    public void Reassemble()
+    {
+        MarkNeedsBuild();
+        VisitChildren(child => child.Reassemble());
+    }
+
     public void Rebuild() => PerformRebuild();
 
     public abstract void PerformRebuild();

--- a/src/FloatSoda/FloatSodaApp.cs
+++ b/src/FloatSoda/FloatSodaApp.cs
@@ -58,6 +58,8 @@ public class FloatSodaApp : IDisposable
     private bool _disposed;
     private readonly ConcurrentQueue<Action> _pendingTasks = new();
 
+    private static readonly ConcurrentDictionary<FloatSodaApp, byte> ActiveApps = new();
+
     internal FloatSodaApp(IFrameLimiter limiter, string appName, ILoggerFactory? loggerFactory = null)
     {
         _limiter = limiter;
@@ -65,6 +67,29 @@ public class FloatSodaApp : IDisposable
         _renderThreadRunner =
             new RenderThreadRunner("RenderThread", limiter, loggerFactory?.CreateLogger<RenderThreadRunner>());
         _logger = loggerFactory?.CreateLogger<FloatSodaApp>();
+        ActiveApps.TryAdd(this, 0);
+    }
+
+    /// <summary>
+    /// ホットリロード（MetadataUpdateHandler）から任意スレッドで呼ばれる。
+    /// 各アプリのメインループにReassembleを積み、次フレームで全Widgetツリーを再ビルドさせる。
+    /// </summary>
+    internal static void ScheduleReassembleAll()
+    {
+        foreach (var app in ActiveApps.Keys)
+        {
+            app._pendingTasks.Enqueue(app.Reassemble);
+        }
+    }
+
+    private void Reassemble()
+    {
+        foreach (var (_, binding) in _bindings)
+        {
+            binding.Reassemble();
+        }
+
+        _logger?.LogInformation("ホットリロード: 全Widgetツリーを再ビルドします");
     }
 
     public void CreateOverlayWindow(string windowName, Widget root, int width, int height,
@@ -188,6 +213,8 @@ public class FloatSodaApp : IDisposable
     private void Dispose(bool disposing)
     {
         if (_disposed) return;
+
+        ActiveApps.TryRemove(this, out _);
 
         if (disposing)
         {

--- a/tests/FloatSoda.Test/Elements/ReassembleTest.cs
+++ b/tests/FloatSoda.Test/Elements/ReassembleTest.cs
@@ -1,0 +1,121 @@
+using FloatSoda.Core;
+using FloatSoda.Elements;
+using FloatSoda.RenderObjects;
+using FloatSoda.Widgets;
+using FloatSoda.Widgets.Layout;
+
+namespace FloatSoda.Test.Elements;
+
+public class ReassembleTest
+{
+    private class BuildLog
+    {
+        public int StatelessBuildCount;
+        public int StatefulBuildCount;
+        public int InitStateCount;
+        public int LastFieldSeen;
+    }
+
+    private record OuterWidget : StatelessWidget
+    {
+        public required BuildLog Log { get; init; }
+
+        public override Widget Build(IBuildContext context)
+        {
+            Log.StatelessBuildCount++;
+            return new InnerWidget { Log = Log };
+        }
+    }
+
+    private record InnerWidget : StatefulWidget<InnerWidget>
+    {
+        public required BuildLog Log { get; init; }
+
+        public override State<InnerWidget> CreateState() => new InnerState();
+    }
+
+    private record InnerState : State<InnerWidget>
+    {
+        private int _field;
+
+        public override void InitState()
+        {
+            Widget!.Log.InitStateCount++;
+            _field = 42;
+        }
+
+        public override Widget Build(IBuildContext context)
+        {
+            Widget!.Log.StatefulBuildCount++;
+            Widget!.Log.LastFieldSeen = _field;
+            return new SizedBox { Width = 10, Height = 10 };
+        }
+    }
+
+    private static (RenderObjectToWidgetElement<RenderView> Root, BuildOwner Owner) MountTree(Widget widget)
+    {
+        var renderView = new RenderView(100, 100);
+        _ = new RenderPipeline
+        {
+            OnNeedVisualUpdate = () => { },
+            RenderView = renderView
+        };
+
+        var owner = new BuildOwner(() => { });
+
+        var root = new RenderObjectToWidgetAdapter
+        {
+            Container = renderView,
+            Child = widget
+        }.AttachToRenderTree(owner, null);
+
+        return (root, owner);
+    }
+
+    [Fact]
+    public void Reassemble_RebuildsAllComponentElements()
+    {
+        var log = new BuildLog();
+        var (root, owner) = MountTree(new OuterWidget { Log = log });
+
+        Assert.Equal(1, log.StatelessBuildCount);
+        Assert.Equal(1, log.StatefulBuildCount);
+
+        root.Reassemble();
+        owner.BuildScope();
+
+        // record等価でBuild結果が変わらなくても、全ComponentElementのBuild()が再実行される
+        Assert.Equal(2, log.StatelessBuildCount);
+        Assert.Equal(2, log.StatefulBuildCount);
+    }
+
+    [Fact]
+    public void Reassemble_PreservesState()
+    {
+        var log = new BuildLog();
+        var (root, owner) = MountTree(new OuterWidget { Log = log });
+
+        root.Reassemble();
+        owner.BuildScope();
+
+        // Stateは再生成されず（InitStateは初回のみ）、フィールド値も保持される
+        Assert.Equal(1, log.InitStateCount);
+        Assert.Equal(42, log.LastFieldSeen);
+    }
+
+    [Fact]
+    public void Reassemble_IsIdempotentAcrossFrames()
+    {
+        var log = new BuildLog();
+        var (root, owner) = MountTree(new OuterWidget { Log = log });
+
+        root.Reassemble();
+        owner.BuildScope();
+        root.Reassemble();
+        owner.BuildScope();
+
+        Assert.Equal(3, log.StatelessBuildCount);
+        Assert.Equal(3, log.StatefulBuildCount);
+        Assert.Equal(1, log.InitStateCount);
+    }
+}


### PR DESCRIPTION
Closes #85

## 概要

`dotnet watch` のホットリロード（MetadataUpdateHandler）を Widget ツリーの再ビルドに接続し、サンプルアプリを再起動せずにUIの変更が反映されるようにします。

## 変更内容

- **Element.Reassemble()** — Flutter の `reassemble` 相当。サブツリー全体を `MarkNeedsBuild()` することで、Widget が record 等価で差分更新がショートサーキットしても全 ComponentElement の `Build()` が新しいメソッド本体で再実行される
- **WidgetBinding.Reassemble()** — ルート Element へ委譲。実際の再ビルドは次フレームの `BuildScope`（Depth順）で実行
- **FloatSodaApp** — 稼働中アプリの static レジストリ（コンストラクタで登録 / Dispose で解除）と `ScheduleReassembleAll()` を追加。ホットリロード通知は任意スレッドで届くため、既存の `_pendingTasks` キュー経由でメインループへマーシャリング
- **HotReloadHandler** — `UpdateApplication` を上記に接続。`ClearCache` は破棄対象キャッシュが未導入のためログのみ（ImageProvider 拡充時に接続する旨をコメントで明示）
- **ReassembleTest**（新規3件）— 全 ComponentElement の Build 再実行 / State のフィールド値保持と InitState の一回性 / 複数フレームにわたる冪等性

## 検証

- `dotnet test`: 79件全合格（新規3件含む）
- `dotnet build`: エラー0
- **実機確認済み**: `dotnet watch run --project samples/FloatSoda.Samples.OverlayApp` 実行中に WatchWidget の Width 変更が再起動なしでオーバーレイに反映されることを確認

## レビュー時の補足

- レンダースレッドとの同期は既存の Layer Clone 渡しの仕組みに乗るため、新規の排他制御は追加していません
- Metadata update 自体の制約（型追加・シグネチャ変更などの rude edit）は `dotnet watch` が再起動にフォールバックする前提でスコープ外です

🤖 Generated with [Claude Code](https://claude.com/claude-code)