### PR TITLE
feat(Widgets): InheritedWidget/InheritedElementの実装とServiceScopeによるDI提供

### DIFF
--- a/src/FloatSoda/Elements/BuildContext.cs
+++ b/src/FloatSoda/Elements/BuildContext.cs
@@ -6,4 +6,7 @@ public interface IBuildContext
 {
     Widget Widget { get; }
     BuildOwner? Owner { get; }
+    T? DependOnInheritedWidgetOfExactType<T>() where T : InheritedWidget;
+
+    InheritedElement? GetElementForInheritedWidgetOfExactType<T>() where T : InheritedWidget;
 }

--- a/src/FloatSoda/Elements/Element.cs
+++ b/src/FloatSoda/Elements/Element.cs
@@ -145,6 +145,25 @@ public abstract class Element : IBuildContext, IComparable<Element>
     {
         child.Parent = null;
         child.DetachRenderObject();
+        child.Deactivate();
+    }
+
+    /// <summary>
+    /// このElement以下のサブツリーをツリーから切り離す際に、依存していた
+    /// <see cref="InheritedElement"/> の被依存リストから自身を除去する。
+    /// これを行わないと、破棄済みElementへ<see cref="DidChangeDependencies"/>が
+    /// 呼ばれ続け、リークの原因になる。
+    /// </summary>
+    protected virtual void Deactivate()
+    {
+        foreach (var dependency in Dependencies)
+        {
+            dependency.RemoveDependent(this);
+        }
+
+        Dependencies.Clear();
+
+        VisitChildren(child => child.Deactivate());
     }
 
     public virtual void DidChangeDependencies() => MarkNeedsBuild();

--- a/src/FloatSoda/Elements/Element.cs
+++ b/src/FloatSoda/Elements/Element.cs
@@ -36,7 +36,41 @@ public abstract class Element : IBuildContext, IComparable<Element>
         protected set => field = value;
     }
 
+    public Dictionary<Type, InheritedElement>? InheritedWidgets { get; set; }
+
+    protected HashSet<InheritedElement> Dependencies { get; } = [];
+
     public BuildOwner? Owner { get; set; }
+
+    private InheritedWidget DependOnInheritedElement(InheritedElement ancestor)
+    {
+        Dependencies.Add(ancestor);
+        ancestor.UpdateDependencies(this);
+        return ancestor.Widget as InheritedWidget;
+    }
+
+    public T? DependOnInheritedWidgetOfExactType<T>() where T : InheritedWidget
+    {
+        if (InheritedWidgets?.TryGetValue(typeof(T), out var ancestor) ?? false)
+        {
+            return DependOnInheritedElement(ancestor) as T;
+        }
+
+        return null;
+    }
+
+    public virtual InheritedElement? GetElementForInheritedWidgetOfExactType<T>() where T : InheritedWidget
+    {
+        if (InheritedWidgets?.TryGetValue(typeof(T), out var inheritedElement) ?? false)
+        {
+            return inheritedElement;
+        }
+
+        return null;
+    }
+
+    protected virtual void UpdateInheritance() => InheritedWidgets = Parent?.InheritedWidgets;
+
     public bool InDirtyList { get; set; }
     public bool Dirty { get; set; }
 
@@ -51,7 +85,10 @@ public abstract class Element : IBuildContext, IComparable<Element>
         {
             Owner = Parent.Owner;
         }
+
+        UpdateInheritance();
     }
+
 
     protected Element? UpdateChild(Element? child, Widget? newWidget)
     {

--- a/src/FloatSoda/Elements/InheritedElement.cs
+++ b/src/FloatSoda/Elements/InheritedElement.cs
@@ -1,9 +1,45 @@
-﻿namespace FloatSoda.Elements;
+﻿using FloatSoda.Widgets;
 
-public class InheritedElement : Element
+namespace FloatSoda.Elements;
+
+public class InheritedElement : ComponentElement
 {
-    public override void PerformRebuild()
+    private HashSet<Element> Dependents { get; } = [];
+    public override Widget Build() => (Widget as InheritedWidget)!.Child;
+
+    protected override void UpdateInheritance()
     {
-        throw new NotImplementedException();
+        var incomingWidgets = Parent?.InheritedWidgets;
+
+        InheritedWidgets = incomingWidgets != null
+            ? new Dictionary<Type, InheritedElement>(incomingWidgets)
+            : [];
+
+        // 祖先マップの有無にかかわらず自分自身を登録する（同型はネストした側で上書き＝最近傍が優先）
+        InheritedWidgets[Widget!.GetType()] = this;
+    }
+
+    public void UpdateDependencies(Element dependent) => Dependents.Add(dependent);
+
+    public override void Update(Widget newWidget)
+    {
+        var oldWidget = Widget as InheritedWidget;
+        base.Update(newWidget);
+
+        if ((Widget as InheritedWidget).UpdateShouldNotify(oldWidget))
+        {
+            NotifyClients();
+        }
+
+        Dirty = true;
+        Rebuild();
+    }
+
+    private void NotifyClients()
+    {
+        foreach (var dependent in Dependents)
+        {
+            dependent.DidChangeDependencies();
+        }
     }
 }

--- a/src/FloatSoda/Elements/InheritedElement.cs
+++ b/src/FloatSoda/Elements/InheritedElement.cs
@@ -4,7 +4,7 @@ namespace FloatSoda.Elements;
 
 public class InheritedElement : ComponentElement
 {
-    private HashSet<Element> Dependents { get; } = [];
+    internal HashSet<Element> Dependents { get; } = [];
     public override Widget Build() => (Widget as InheritedWidget)!.Child;
 
     protected override void UpdateInheritance()
@@ -20,6 +20,8 @@ public class InheritedElement : ComponentElement
     }
 
     public void UpdateDependencies(Element dependent) => Dependents.Add(dependent);
+
+    public void RemoveDependent(Element dependent) => Dependents.Remove(dependent);
 
     public override void Update(Widget newWidget)
     {

--- a/src/FloatSoda/FloatSoda.csproj
+++ b/src/FloatSoda/FloatSoda.csproj
@@ -11,6 +11,10 @@
     </ItemGroup>
 
     <ItemGroup>
+      <InternalsVisibleTo Include="FloatSoda.Test" />
+    </ItemGroup>
+
+    <ItemGroup>
       <PackageReference Include="Polly" Version="8.6.6" />
       <PackageReference Include="SkiaSharp.HarfBuzz" Version="3.119.4" />
       <PackageReference Include="Topten.RichTextKit" Version="0.4.167" />

--- a/src/FloatSoda/Widgets/InheritedWidget.cs
+++ b/src/FloatSoda/Widgets/InheritedWidget.cs
@@ -4,7 +4,9 @@ namespace FloatSoda.Widgets;
 
 public abstract record InheritedWidget : Widget
 {
-    public override Element CreateElement() => new InheritedElement();
+    public required Widget Child { get; init; }
+
+    public override Element CreateElement() => new InheritedElement() { Widget = this };
 
     public abstract bool UpdateShouldNotify(InheritedWidget oldWidget);
 }

--- a/src/FloatSoda/Widgets/ServiceScope.cs
+++ b/src/FloatSoda/Widgets/ServiceScope.cs
@@ -1,0 +1,27 @@
+﻿using FloatSoda.Elements;
+
+namespace FloatSoda.Widgets;
+
+public record ServiceScope : InheritedWidget
+{
+    public required IServiceProvider Services { get; init; }
+
+    public static IServiceProvider Of(IBuildContext context)
+    {
+        return context.DependOnInheritedWidgetOfExactType<ServiceScope>()?.Services ??
+               throw new InvalidOperationException("ServiceScopeが祖先に見つかりません。");
+    }
+
+    public override bool UpdateShouldNotify(InheritedWidget oldWidget)
+    {
+        return oldWidget is ServiceScope oldScope && !ReferenceEquals(oldScope.Services, Services);
+    }
+}
+
+public static class ServiceScopeExtension
+{
+    public static T Resolve<T>(this IBuildContext context) where T : notnull
+    {
+        return (T)ServiceScope.Of(context).GetService(typeof(T))!;
+    }
+}

--- a/tests/FloatSoda.Test/Elements/InheritedWidgetTest.cs
+++ b/tests/FloatSoda.Test/Elements/InheritedWidgetTest.cs
@@ -1,0 +1,177 @@
+using FloatSoda.Core;
+using FloatSoda.Elements;
+using FloatSoda.RenderObjects;
+using FloatSoda.Widgets;
+using FloatSoda.Widgets.Layout;
+
+namespace FloatSoda.Test.Elements;
+
+public class InheritedWidgetTest
+{
+    private record ScopeA : InheritedWidget
+    {
+        public required int Value { get; init; }
+
+        public override bool UpdateShouldNotify(InheritedWidget oldWidget) =>
+            oldWidget is ScopeA old && old.Value != Value;
+    }
+
+    private record ScopeB : InheritedWidget
+    {
+        public required string Name { get; init; }
+
+        public override bool UpdateShouldNotify(InheritedWidget oldWidget) =>
+            oldWidget is ScopeB old && old.Name != Name;
+    }
+
+    /// <summary>Build時に祖先のInheritedWidgetを探索し、見つかった値を記録するプローブ。</summary>
+    private record Probe : StatelessWidget
+    {
+        public required Action<IBuildContext> OnBuild { get; init; }
+
+        public override Widget Build(IBuildContext context)
+        {
+            OnBuild(context);
+            return new SizedBox { Width = 10, Height = 10 };
+        }
+    }
+
+    private static (RenderObjectToWidgetElement<RenderView> Root, BuildOwner Owner) MountTree(Widget widget)
+    {
+        var renderView = new RenderView(100, 100);
+        _ = new RenderPipeline
+        {
+            OnNeedVisualUpdate = () => { },
+            RenderView = renderView
+        };
+
+        var owner = new BuildOwner(() => { });
+
+        var root = new RenderObjectToWidgetAdapter
+        {
+            Container = renderView,
+            Child = widget
+        }.AttachToRenderTree(owner, null);
+
+        return (root, owner);
+    }
+
+    [Fact]
+    public void SingleScope_DescendantCanDependOnIt()
+    {
+        ScopeA? found = null;
+
+        MountTree(new ScopeA
+        {
+            Value = 1,
+            Child = new Probe
+            {
+                OnBuild = ctx => found = ctx.DependOnInheritedWidgetOfExactType<ScopeA>()
+            }
+        });
+
+        Assert.NotNull(found);
+        Assert.Equal(1, found!.Value);
+    }
+
+    [Fact]
+    public void NestedDifferentScopes_DescendantFindsBoth()
+    {
+        ScopeA? foundA = null;
+        ScopeB? foundB = null;
+
+        MountTree(new ScopeA
+        {
+            Value = 1,
+            Child = new ScopeB
+            {
+                Name = "inner",
+                Child = new Probe
+                {
+                    OnBuild = ctx =>
+                    {
+                        foundA = ctx.DependOnInheritedWidgetOfExactType<ScopeA>();
+                        foundB = ctx.DependOnInheritedWidgetOfExactType<ScopeB>();
+                    }
+                }
+            }
+        });
+
+        // 外側のScopeAはコピーされたマップ経由で見つかる
+        Assert.NotNull(foundA);
+        Assert.Equal(1, foundA!.Value);
+
+        // 内側のScopeBは自分自身をマップに登録していないと見つからない
+        Assert.NotNull(foundB);
+        Assert.Equal("inner", foundB!.Name);
+    }
+
+    [Fact]
+    public void NestedSameType_InnerScopeShadowsOuter()
+    {
+        ScopeA? found = null;
+
+        MountTree(new ScopeA
+        {
+            Value = 1,
+            Child = new ScopeA
+            {
+                Value = 2,
+                Child = new Probe
+                {
+                    OnBuild = ctx => found = ctx.DependOnInheritedWidgetOfExactType<ScopeA>()
+                }
+            }
+        });
+
+        // Flutter同様、最も近い祖先が優先される
+        Assert.NotNull(found);
+        Assert.Equal(2, found!.Value);
+    }
+
+    [Fact]
+    public void DependOn_ReturnsNull_WhenNoAncestorExists()
+    {
+        ScopeA? found = new ScopeA { Value = -1, Child = new SizedBox() };
+
+        MountTree(new Probe
+        {
+            OnBuild = ctx => found = ctx.DependOnInheritedWidgetOfExactType<ScopeA>()
+        });
+
+        Assert.Null(found);
+    }
+
+    [Fact]
+    public void GetElementFor_ReturnsNull_WhenTypeNotRegistered()
+    {
+        var buildRan = false;
+        InheritedElement? found = null;
+        Exception? thrown = null;
+
+        MountTree(new ScopeA
+        {
+            Value = 1,
+            Child = new Probe
+            {
+                OnBuild = ctx =>
+                {
+                    buildRan = true;
+                    try
+                    {
+                        found = ctx.GetElementForInheritedWidgetOfExactType<ScopeB>();
+                    }
+                    catch (Exception e)
+                    {
+                        thrown = e;
+                    }
+                }
+            }
+        });
+
+        // 未登録の型はnullを返すべき（KeyNotFoundExceptionを投げない）
+        Assert.True(buildRan);
+        Assert.Null(thrown);
+        Assert.Null(found);
+    }
+}

--- a/tests/FloatSoda.Test/Elements/InheritedWidgetTest.cs
+++ b/tests/FloatSoda.Test/Elements/InheritedWidgetTest.cs
@@ -36,7 +36,7 @@ public class InheritedWidgetTest
         }
     }
 
-    private static (RenderObjectToWidgetElement<RenderView> Root, BuildOwner Owner) MountTree(Widget widget)
+    private static (RenderObjectToWidgetElement<RenderView> Root, BuildOwner Owner, RenderView RenderView) MountTree(Widget widget)
     {
         var renderView = new RenderView(100, 100);
         _ = new RenderPipeline
@@ -53,7 +53,21 @@ public class InheritedWidgetTest
             Child = widget
         }.AttachToRenderTree(owner, null);
 
-        return (root, owner);
+        return (root, owner, renderView);
+    }
+
+    /// <summary>ルートWidgetを差し替えて再ビルドまで実行する。</summary>
+    private static void ReattachRoot(
+        (RenderObjectToWidgetElement<RenderView> Root, BuildOwner Owner, RenderView RenderView) tree,
+        Widget widget)
+    {
+        new RenderObjectToWidgetAdapter
+        {
+            Container = tree.RenderView,
+            Child = widget
+        }.AttachToRenderTree(tree.Owner, tree.Root);
+
+        tree.Owner.BuildScope();
     }
 
     [Fact]
@@ -140,6 +154,69 @@ public class InheritedWidgetTest
         });
 
         Assert.Null(found);
+    }
+
+    [Fact]
+    public void DeactivatedDependent_IsRemovedFromDependents()
+    {
+        InheritedElement? scopeElement = null;
+        var buildCount = 0;
+
+        var tree = MountTree(new ScopeA
+        {
+            Value = 1,
+            Child = new Probe
+            {
+                OnBuild = ctx =>
+                {
+                    buildCount++;
+                    ctx.DependOnInheritedWidgetOfExactType<ScopeA>();
+                    scopeElement = ctx.GetElementForInheritedWidgetOfExactType<ScopeA>();
+                }
+            }
+        });
+
+        Assert.NotNull(scopeElement);
+        Assert.Single(scopeElement!.Dependents);
+        Assert.Equal(1, buildCount);
+
+        // Probeを別型のWidgetに差し替えてdeactivateさせる（ScopeA自体は同型なのでin-place更新）
+        ReattachRoot(tree, new ScopeA { Value = 1, Child = new SizedBox() });
+
+        Assert.Empty(scopeElement.Dependents);
+
+        // Scopeの値を変えて通知を発火させても、破棄済みのProbeは再ビルドされない
+        ReattachRoot(tree, new ScopeA { Value = 2, Child = new SizedBox() });
+
+        Assert.Equal(1, buildCount);
+    }
+
+    [Fact]
+    public void SurvivingDependent_StaysInDependents_AfterScopeUpdate()
+    {
+        InheritedElement? scopeElement = null;
+        var buildCount = 0;
+
+        Probe CreateProbe() => new()
+        {
+            OnBuild = ctx =>
+            {
+                buildCount++;
+                ctx.DependOnInheritedWidgetOfExactType<ScopeA>();
+                scopeElement = ctx.GetElementForInheritedWidgetOfExactType<ScopeA>();
+            }
+        };
+
+        var tree = MountTree(new ScopeA { Value = 1, Child = CreateProbe() });
+
+        Assert.Equal(1, buildCount);
+
+        // 同型のProbeを保ったままScopeの値だけ変える → Probeはin-place更新で生存
+        ReattachRoot(tree, new ScopeA { Value = 2, Child = CreateProbe() });
+
+        Assert.NotNull(scopeElement);
+        Assert.Single(scopeElement!.Dependents);
+        Assert.True(buildCount >= 2);
     }
 
     [Fact]


### PR DESCRIPTION
Closes #56

## 概要

Flutter流の `InheritedWidget` / `InheritedElement` を実装し、その最初の利用例として `IServiceProvider` をツリーに流す `ServiceScope` を追加します。

## 変更内容

### Element (`src/FloatSoda/Elements/Element.cs`)
- `InheritedWidgets` マップ(`Dictionary<Type, InheritedElement>`)を追加し、`Mount()` 時に `UpdateInheritance()` で親から伝播
- `DependOnInheritedWidgetOfExactType<T>()` — 最近傍の祖先 `InheritedWidget` を取得し、依存関係を登録
- `GetElementForInheritedWidgetOfExactType<T>()` — 依存登録なしで `InheritedElement` を取得(未登録型は null)
- `Deactivate()` — 非活性化時にサブツリー全体の依存を `InheritedElement.Dependents` から除去(破棄済みElementへの通知・リークを防止)

### InheritedElement (`src/FloatSoda/Elements/InheritedElement.cs`)
- `ComponentElement` ベースで `Child` をそのままビルド
- `Dependents` に依存要素を保持し、`Update()` 時に `UpdateShouldNotify()` が true なら `DidChangeDependencies()` を通知
- `UpdateInheritance()` は祖先マップをコピーした上で**無条件に自分自身を登録**(インデクサ代入により同型ネストは最近傍が優先)

### ServiceScope (`src/FloatSoda/Widgets/ServiceScope.cs`)
- `IServiceProvider` を公開する `InheritedWidget`。`ServiceScope.Of(context)` と `context.Resolve<T>()` 拡張メソッドを提供
- `UpdateShouldNotify` は `Services` の参照比較

## 修正したバグ

実装途中の `UpdateInheritance()` は祖先マップが存在する場合に自分自身をマップへ登録していなかったため:
- ネストした2つ目以降の `InheritedWidget` が子孫から一切見つからない
- 同型の `InheritedWidget` をネストしても内側でシャドウされない

の2つの不具合がありました。コピー後に `InheritedWidgets[Widget.GetType()] = this` を必ず実行することで解消しています。

また、`Dependents` が追加のみでクリーンアップされない問題も `Deactivate()` の導入で解消済みです。

## 完了条件(#56)との対応

- ✅ 子孫が BuildContext 経由で InheritedWidget を取得・依存登録できる — `DependOnInheritedWidgetOfExactType<T>()`
- ✅ UpdateShouldNotify が true のとき依存エレメントが再ビルドされる — `InheritedElement.Update()` → `NotifyClients()` → `DidChangeDependencies()`

## テスト

`tests/FloatSoda.Test/Elements/InheritedWidgetTest.cs` を追加(7ケース):
- 単一スコープの取得
- 異型ネスト(外側・内側の両方が見つかる)← 修正前は失敗
- 同型ネストのシャドウイング(最近傍優先)← 修正前は失敗
- 祖先なしで null
- 未登録型の `GetElementFor...` が例外でなく null
- 非活性化された依存要素が `Dependents` から除去され、通知されない
- 生存する依存要素はスコープ更新後も `Dependents` に残る

全テストスイート: FloatSoda.Test 86件 + FloatSoda.Common.Test 7件 全合格。

## レビュー時の注意点

- `InheritedWidget` 配下の各 `Element` の `Mount` で辞書をコピーするため O(深さ×要素数)。Flutterは永続ハッシュマップで回避しており、将来の最適化候補です
- テストから `Dependents` を検証するため `InternalsVisibleTo("FloatSoda.Test")` を追加しています
- `samples/.../StackWidget.cs` の実験用コード(`Widgetw`)はコミットから除外しています

🤖 Generated with [Claude Code](https://claude.com/claude-code)