### PR TITLE
feat(Widgets): WindowWidgetを実装しオーバーレイ生成責務をWidget側へ移動

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -58,13 +58,13 @@ Widget root = new Align
 };
 
 // ダッシュボードオーバーレイ（サイズは root のレイアウト結果に自動追従）
-app.CreateWindow(new DashboardWindow { WindowKey = "MyDashboard", Child = root });
+app.CreateWindow(new DashboardWindow { Title = "MyDashboard", Child = root });
 
 // ワールド座標固定（メートル単位）
-// app.CreateWindow(new WorldSpaceWindow { WindowKey = "MyWorld", Child = root, Position = new Vector3(0, 1, -1) });
+// app.CreateWindow(new WorldSpaceWindow { Title = "MyWorld", Child = root, Position = new Vector3(0, 1, -1) });
 
 // デバイス追従
-// app.CreateWindow(new DeviceTrackedWindow { WindowKey = "MyHand", Child = root, Target = TrackedDevice.LeftController });
+// app.CreateWindow(new DeviceTrackedWindow { Title = "MyHand", Child = root, Target = TrackedDevice.LeftController });
 
 app.Run();
 ```

--- a/Readme.md
+++ b/Readme.md
@@ -57,14 +57,14 @@ Widget root = new Align
     }
 };
 
-// ダッシュボードオーバーレイ
-app.CreateDashboardOverlay("MyDashboard", root, 1000, 1000);
+// ダッシュボードオーバーレイ（サイズは root のレイアウト結果に自動追従）
+app.CreateWindow(new DashboardWindow { WindowKey = "MyDashboard", Child = root });
 
 // ワールド座標固定（メートル単位）
-// app.CreateWorldSpaceOverlay("MyWorld", root, 1000, 1000, new Vector3(0, 1, -1));
+// app.CreateWindow(new WorldSpaceWindow { WindowKey = "MyWorld", Child = root, Position = new Vector3(0, 1, -1) });
 
 // デバイス追従
-// app.CreateTrackingOverlay("MyHand", root, 1000, 1000, TrackedDevice.LeftController);
+// app.CreateWindow(new DeviceTrackedWindow { WindowKey = "MyHand", Child = root, Target = TrackedDevice.LeftController });
 
 app.Run();
 ```

--- a/Readme.md
+++ b/Readme.md
@@ -60,8 +60,8 @@ Widget root = new Align
 // ダッシュボードオーバーレイ（サイズは root のレイアウト結果に自動追従）
 app.CreateWindow(new DashboardWindow { Title = "MyDashboard", Child = root });
 
-// ワールド座標固定（メートル単位）
-// app.CreateWindow(new WorldSpaceWindow { Title = "MyWorld", Child = root, Position = new Vector3(0, 1, -1) });
+// ワールド座標固定（メートル単位。Position 省略時は前方1m・高さ1m）
+// app.CreateWindow(new WorldSpaceWindow { Title = "MyWorld", Child = root });
 
 // デバイス追従
 // app.CreateWindow(new DeviceTrackedWindow { Title = "MyHand", Child = root, Target = TrackedDevice.LeftController });

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -60,7 +60,8 @@ Widget root = new Center
     }
 };
 
-app.CreateDashboardOverlay("HelloWorld", root, 1000, 1000);
+// オーバーレイのサイズは root ウィジェットのレイアウト結果に自動追従します。
+app.CreateWindow(new DashboardWindow { WindowKey = "HelloWorld", Child = root });
 
 app.Run();
 ```
@@ -96,7 +97,8 @@ var root = new RenderPositionedBox
     }
 };
 
-app.CreateDashboardOverlay("HelloWorld", root, 1000, 1000);
+// CreateWindow の Child は Widget を要求するため、RenderObject を直接ルートにする場合は
+// RenderObjectWidget でラップして渡します。
 app.Run();
 ```
 </details>
@@ -105,23 +107,25 @@ app.Run();
 
 ## オーバーレイ種別の選び方
 
-`FloatSodaApp` には 3 種類のオーバーレイ作成メソッドがあります。
+`app.CreateWindow(...)` に渡すウィンドウ定義 `WindowWidget` の種類でオーバーレイ種別を選びます。
+`Size` を指定しない場合、オーバーレイのサイズは `Child` ウィジェットのレイアウト結果に追従します
+（`Size` を指定するとそのサイズで固定されます）。
 
-| メソッド | オーバーレイ種別 | 位置の管理 |
+| ウィンドウ定義 | オーバーレイ種別 | 位置の管理 |
 |---|---|---|
-| `CreateDashboardOverlay(name, root, w, h)` | `DashboardOverlay` | SteamVR ダッシュボードが管理（ユーザーが開くタブ） |
-| `CreateWorldSpaceOverlay(name, root, w, h, position)` | `WorldSpaceOverlay` | ワールド座標で固定（`Vector3 position`） |
-| `CreateTrackingOverlay(name, root, w, h, device)` | `DeviceTrackedOverlay` | トラッキングデバイスに追従（`TrackedDevice` 列挙体） |
+| `DashboardWindow { WindowKey, Child, Size? }` | `DashboardOverlay` | SteamVR ダッシュボードが管理（ユーザーが開くタブ） |
+| `WorldSpaceWindow { WindowKey, Child, Size?, Position, Rotation }` | `WorldSpaceOverlay` | ワールド座標で固定（`Vector3 Position`） |
+| `DeviceTrackedWindow { WindowKey, Child, Size?, Target, Offset, Rotation }` | `DeviceTrackedOverlay` | トラッキングデバイスに追従（`TrackedDevice` 列挙体） |
 
 ```csharp
 // ダッシュボード
-app.CreateDashboardOverlay("MyDashboard", root, 1000, 1000);
+app.CreateWindow(new DashboardWindow { WindowKey = "MyDashboard", Child = root });
 
 // ワールド座標 (x=0, y=1, z=-1 メートル)
-app.CreateWorldSpaceOverlay("MyWorld", root, 1000, 1000, new Vector3(0, 1, -1));
+app.CreateWindow(new WorldSpaceWindow { WindowKey = "MyWorld", Child = root, Position = new Vector3(0, 1, -1) });
 
 // 左コントローラーに追従
-app.CreateTrackingOverlay("MyHand", root, 1000, 1000, TrackedDevice.LeftController);
+app.CreateWindow(new DeviceTrackedWindow { WindowKey = "MyHand", Child = root, Target = TrackedDevice.LeftController });
 ```
 
 ---

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -114,7 +114,7 @@ app.Run();
 | ウィンドウ定義 | オーバーレイ種別 | 位置の管理 |
 |---|---|---|
 | `DashboardWindow { Title, Child, Size? }` | `DashboardOverlay` | SteamVR ダッシュボードが管理（ユーザーが開くタブ） |
-| `WorldSpaceWindow { Title, Child, Size?, Position, Rotation }` | `WorldSpaceOverlay` | ワールド座標で固定（`Vector3 Position`） |
+| `WorldSpaceWindow { Title, Child, Size?, Position, Rotation }` | `WorldSpaceOverlay` | ワールド座標で固定（`Vector3 Position`、既定は前方1m・高さ1m） |
 | `DeviceTrackedWindow { Title, Child, Size?, Target, Offset, Rotation }` | `DeviceTrackedOverlay` | トラッキングデバイスに追従（`TrackedDevice` 列挙体） |
 
 `Title` は SteamVR 上の表示名（ダッシュボードタブ名など）です。OpenVR のオーバーレイキーは
@@ -125,8 +125,8 @@ app.Run();
 // ダッシュボード
 app.CreateWindow(new DashboardWindow { Title = "MyDashboard", Child = root });
 
-// ワールド座標 (x=0, y=1, z=-1 メートル)
-app.CreateWindow(new WorldSpaceWindow { Title = "MyWorld", Child = root, Position = new Vector3(0, 1, -1) });
+// ワールド座標固定。Position 省略時はプレイエリア中央から前方1m・高さ1m (0, 1, -1)
+app.CreateWindow(new WorldSpaceWindow { Title = "MyWorld", Child = root });
 
 // 左コントローラーに追従
 app.CreateWindow(new DeviceTrackedWindow { Title = "MyHand", Child = root, Target = TrackedDevice.LeftController });

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -61,7 +61,7 @@ Widget root = new Center
 };
 
 // オーバーレイのサイズは root ウィジェットのレイアウト結果に自動追従します。
-app.CreateWindow(new DashboardWindow { WindowKey = "HelloWorld", Child = root });
+app.CreateWindow(new DashboardWindow { Title = "HelloWorld", Child = root });
 
 app.Run();
 ```
@@ -113,19 +113,23 @@ app.Run();
 
 | ウィンドウ定義 | オーバーレイ種別 | 位置の管理 |
 |---|---|---|
-| `DashboardWindow { WindowKey, Child, Size? }` | `DashboardOverlay` | SteamVR ダッシュボードが管理（ユーザーが開くタブ） |
-| `WorldSpaceWindow { WindowKey, Child, Size?, Position, Rotation }` | `WorldSpaceOverlay` | ワールド座標で固定（`Vector3 Position`） |
-| `DeviceTrackedWindow { WindowKey, Child, Size?, Target, Offset, Rotation }` | `DeviceTrackedOverlay` | トラッキングデバイスに追従（`TrackedDevice` 列挙体） |
+| `DashboardWindow { Title, Child, Size? }` | `DashboardOverlay` | SteamVR ダッシュボードが管理（ユーザーが開くタブ） |
+| `WorldSpaceWindow { Title, Child, Size?, Position, Rotation }` | `WorldSpaceOverlay` | ワールド座標で固定（`Vector3 Position`） |
+| `DeviceTrackedWindow { Title, Child, Size?, Target, Offset, Rotation }` | `DeviceTrackedOverlay` | トラッキングデバイスに追従（`TrackedDevice` 列挙体） |
+
+`Title` は SteamVR 上の表示名（ダッシュボードタブ名など）です。OpenVR のオーバーレイキーは
+「エントリアセンブリ名 + `Title` のスネークケース」から自動生成されます
+（例: アセンブリ `MyOverlayApp` + `Title = "My Dashboard"` → `my_overlay_app.my_dashboard`）。
 
 ```csharp
 // ダッシュボード
-app.CreateWindow(new DashboardWindow { WindowKey = "MyDashboard", Child = root });
+app.CreateWindow(new DashboardWindow { Title = "MyDashboard", Child = root });
 
 // ワールド座標 (x=0, y=1, z=-1 メートル)
-app.CreateWindow(new WorldSpaceWindow { WindowKey = "MyWorld", Child = root, Position = new Vector3(0, 1, -1) });
+app.CreateWindow(new WorldSpaceWindow { Title = "MyWorld", Child = root, Position = new Vector3(0, 1, -1) });
 
 // 左コントローラーに追従
-app.CreateWindow(new DeviceTrackedWindow { WindowKey = "MyHand", Child = root, Target = TrackedDevice.LeftController });
+app.CreateWindow(new DeviceTrackedWindow { Title = "MyHand", Child = root, Target = TrackedDevice.LeftController });
 ```
 
 ---

--- a/docs/OVRIntegration.md
+++ b/docs/OVRIntegration.md
@@ -168,5 +168,5 @@ OpenVR.Overlay.SetOverlayTransformAbsolute(handle, origin, ref hmd);
 
 ## 関連ページ
 
-- [GettingStarted](GettingStarted.md) — オーバーレイ作成の高レベル API(`CreateDashboardOverlay` など)
+- [GettingStarted](GettingStarted.md) — オーバーレイ作成の高レベル API(`CreateWindow` と `DashboardWindow` など)
 - [Architecture](Architecture.md) — オーバーレイテクスチャへのレンダリング経路

--- a/samples/FloatSoda.Samples.OverlayApp/Program.cs
+++ b/samples/FloatSoda.Samples.OverlayApp/Program.cs
@@ -1,19 +1,30 @@
 ﻿using FloatSoda;
 using FloatSoda.OVR.Overlay;
 using FloatSoda.Samples.OverlayApp;
-using SkiaSharp;
+using FloatSoda.Widgets;
 
 var builder = FloatSodaAppBuilder.CreateDefault();
 
 using var app = builder.Build();
 
-var size = new SKSizeI(1000, 1000);
+// Size 未指定のウィンドウは Child のレイアウト結果にサイズが追従する。
+app.CreateWindow(new DashboardWindow
+{
+    WindowKey = "FloatSodaDashboard",
+    Child = new StackWidget()
+});
 
+app.CreateWindow(new DashboardWindow
+{
+    WindowKey = "WatchDashBoard",
+    Child = new WatchWidget()
+});
 
-app.CreateDashboardOverlay("FloatSodaDashboard", new StackWidget { Width = size.Width, Height = size.Height },
-    size.Width, size.Width);
-
-app.CreateDashboardOverlay("WatchDashBoard", new WatchWidget(), size.Width, size.Height);
-app.CreateTrackingOverlay("Left Hand", new WatchWidget(), size.Width, size.Height, TrackedDevice.LeftController);
+app.CreateWindow(new DeviceTrackedWindow
+{
+    WindowKey = "Left Hand",
+    Child = new WatchWidget(),
+    Target = TrackedDevice.LeftController
+});
 
 app.Run();

--- a/samples/FloatSoda.Samples.OverlayApp/Program.cs
+++ b/samples/FloatSoda.Samples.OverlayApp/Program.cs
@@ -10,19 +10,19 @@ using var app = builder.Build();
 // Size 未指定のウィンドウは Child のレイアウト結果にサイズが追従する。
 app.CreateWindow(new DashboardWindow
 {
-    WindowKey = "FloatSodaDashboard",
+    Title = "FloatSodaDashboard",
     Child = new StackWidget()
 });
 
 app.CreateWindow(new DashboardWindow
 {
-    WindowKey = "WatchDashBoard",
+    Title = "WatchDashBoard",
     Child = new WatchWidget()
 });
 
 app.CreateWindow(new DeviceTrackedWindow
 {
-    WindowKey = "Left Hand",
+    Title = "Left Hand",
     Child = new WatchWidget(),
     Target = TrackedDevice.LeftController
 });

--- a/samples/FloatSoda.Samples.OverlayApp/Program.cs
+++ b/samples/FloatSoda.Samples.OverlayApp/Program.cs
@@ -27,4 +27,11 @@ app.CreateWindow(new DeviceTrackedWindow
     Target = TrackedDevice.LeftController
 });
 
+// Position 省略時はプレイエリア中央から前方1m・高さ1mに表示される。
+app.CreateWindow(new WorldSpaceWindow
+{
+    Title = "WorldSpace Watch",
+    Child = new WatchWidget()
+});
+
 app.Run();

--- a/samples/FloatSoda.Samples.OverlayApp/StackWidget.cs
+++ b/samples/FloatSoda.Samples.OverlayApp/StackWidget.cs
@@ -9,8 +9,8 @@ namespace FloatSoda.Samples.OverlayApp;
 
 public record StackWidget : StatelessWidget
 {
-    public required double Width { get; init; }
-    public required double Height { get; init; }
+    public double Width { get; init; } = 1000;
+    public double Height { get; init; } = 1000;
 
     public override Widget Build(IBuildContext context)
 

--- a/src/FloatSoda.Engine/GLView.cs
+++ b/src/FloatSoda.Engine/GLView.cs
@@ -7,15 +7,17 @@ namespace FloatSoda.Engine;
 public class GLView : IDisposable
 {
     public GRContext GrContext { get; }
-    public SKSurface Surface { get; }
-    public int TextureHandle { get; }
-    public SKSizeI Size { get; set; } = new(1000, 1000);
+    public SKSurface Surface { get; private set; }
+    public int TextureHandle { get; private set; }
+    public SKSizeI Size { get; private set; }
 
     private readonly unsafe Window* _window;
     private bool _disposed;
 
-    public GLView()
+    public GLView(SKSizeI? initialSize = null)
     {
+        Size = initialSize ?? new SKSizeI(1000, 1000);
+
         unsafe
         {
             GLFW.WindowHint(WindowHintBool.Visible, false);
@@ -31,29 +33,72 @@ public class GLView : IDisposable
         GrContext = GRContext.CreateGl(GRGlInterface.Create()) ??
                     throw new InvalidOperationException("GRGContextの作成に失敗しました");
 
+        (TextureHandle, Surface) = CreateTextureAndSurface(Size);
+    }
 
-        TextureHandle = GL.GenTexture();
+    private (int textureHandle, SKSurface surface) CreateTextureAndSurface(SKSizeI size)
+    {
+        var textureHandle = GL.GenTexture();
 
-        GL.BindTexture(TextureTarget.Texture2D, TextureHandle);
+        GL.BindTexture(TextureTarget.Texture2D, textureHandle);
         GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureMinFilter, (int)TextureMinFilter.Linear);
         GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureMagFilter, (int)TextureMagFilter.Linear);
-        GL.TexImage2D(TextureTarget.Texture2D, 0, PixelInternalFormat.Rgba8, Size.Width, Size.Height, 0,
+        GL.TexImage2D(TextureTarget.Texture2D, 0, PixelInternalFormat.Rgba8, size.Width, size.Height, 0,
             PixelFormat.Rgba,
             PixelType.UnsignedByte, IntPtr.Zero);
 
-        var backendTexture = new GRBackendTexture(Size.Width, Size.Height, false, new GRGlTextureInfo
+        using var backendTexture = new GRBackendTexture(size.Width, size.Height, false, new GRGlTextureInfo
         {
-            Id = (uint)TextureHandle,
+            Id = (uint)textureHandle,
             Target = (uint)TextureTarget.Texture2D,
             Format = (uint)InternalFormat.Rgba8
         });
 
-        Surface = SKSurface.Create(GrContext, backendTexture, GRSurfaceOrigin.BottomLeft, SKColorType.Rgba8888) ??
-                  throw new InvalidOperationException("SKSurfaceの作成に失敗しました。");
+        var surface = SKSurface.Create(GrContext, backendTexture, GRSurfaceOrigin.BottomLeft, SKColorType.Rgba8888) ??
+                      throw new InvalidOperationException("SKSurfaceの作成に失敗しました。");
+
+        return (textureHandle, surface);
     }
+
+    /// <summary>
+    /// 描画先のサイズを変更します。既存のテクスチャとSurfaceは破棄され、再作成されます。
+    /// </summary>
+    public void Resize(int width, int height)
+    {
+        if (width <= 0 || height <= 0)
+            throw new ArgumentOutOfRangeException(nameof(width), "幅・高さは正の値である必要があります。");
+
+        if (Size.Width == width && Size.Height == height)
+            return; // サイズが変わらないなら何もしない
+
+        unsafe
+        {
+            GLFW.MakeContextCurrent(_window);
+        }
+        GrContext.ResetContext();
+
+        // 古いリソースを破棄
+        Surface.Dispose();
+        if (TextureHandle != 0)
+        {
+            GL.DeleteTexture(TextureHandle);
+        }
+
+        Size = new SKSizeI(width, height);
+        (var newTextureHandle, var newSurface) = CreateTextureAndSurface(Size);
+
+        TextureHandle = newTextureHandle;
+        Surface = newSurface;
+    }
+
+    public void Resize(SKSizeI size) => Resize(size.Width, size.Height);
 
     public void Clear()
     {
+        unsafe
+        {
+            GLFW.MakeContextCurrent(_window);
+        }
         GrContext.ResetContext();
 
         Surface.Canvas.Clear(SKColors.Transparent);
@@ -65,7 +110,6 @@ public class GLView : IDisposable
         GrContext.Flush();
         GL.Flush();
     }
-
 
     public void Dispose()
     {

--- a/src/FloatSoda.Engine/IWindow.cs
+++ b/src/FloatSoda.Engine/IWindow.cs
@@ -8,4 +8,9 @@ public interface IWindow : IDisposable
     ILayer Root { get; set; }
 
     void Update();
+
+    /// <summary>
+    /// 描画先テクスチャ／サーフェスのサイズを変更します。レンダースレッド上で呼ぶ必要があります。
+    /// </summary>
+    void Resize(int width, int height);
 }

--- a/src/FloatSoda.Engine/OverlayWindow.cs
+++ b/src/FloatSoda.Engine/OverlayWindow.cs
@@ -31,5 +31,7 @@ public class OverlayWindow(IOverlay overlay, Renderer renderer) : IWindow
         Overlay.Texture.FromTexture_t(texture);
     }
 
+    public void Resize(int width, int height) => renderer.Resize(width, height);
+
     public void Dispose() => Overlay.Dispose();
 }

--- a/src/FloatSoda.Engine/Renderer.cs
+++ b/src/FloatSoda.Engine/Renderer.cs
@@ -19,5 +19,8 @@ public class Renderer : IDisposable
         GLView.Flush();
     }
 
+    /// <summary>描画先の GLView を指定サイズにリサイズします。GL 呼び出しのためレンダースレッド上で呼びます。</summary>
+    public void Resize(int width, int height) => GLView.Resize(width, height);
+
     public void Dispose() => GLView.Dispose();
 }

--- a/src/FloatSoda/Core/WidgetBinding.cs
+++ b/src/FloatSoda/Core/WidgetBinding.cs
@@ -5,6 +5,7 @@ using FloatSoda.OVR.Overlay;
 using FloatSoda.RenderObjects;
 using FloatSoda.Widgets;
 using SkiaSharp;
+using OverlayWindow = FloatSoda.Engine.OverlayWindow;
 
 namespace FloatSoda.Core;
 

--- a/src/FloatSoda/Core/WidgetBinding.cs
+++ b/src/FloatSoda/Core/WidgetBinding.cs
@@ -27,8 +27,11 @@ public class WidgetBinding
 
     public SKSizeI Size => Pipeline?.RenderView.Size.ToSizeI() ?? SKSizeI.Empty;
 
+    /// <summary>直近でレンダースレッドへ通知したオーバーレイサイズ。変化検知に使用する。</summary>
+    private SKSizeI _lastPostedSize = SKSizeI.Empty;
 
-    public void EnsureInitialized(string windowName, SKSize size, RenderThreadRunner renderThreadRunner,
+
+    public void EnsureInitialized(string windowName, RenderThreadRunner renderThreadRunner,
         Func<string, IOverlay> overlayFactory)
     {
         if (Initialized) return;
@@ -42,10 +45,7 @@ public class WidgetBinding
         {
             var renderer = new Renderer
             {
-                GLView = new GLView
-                {
-                    Size = Size
-                }
+                GLView = new GLView(Size)
             };
 
             var overlay = overlayFactory(WindowName);
@@ -57,7 +57,7 @@ public class WidgetBinding
         Pipeline = new RenderPipeline
         {
             OnNeedVisualUpdate = EnsureVisualUpdate,
-            RenderView = new RenderView(size.Width, size.Height)
+            RenderView = new RenderView()
         };
 
         Pipeline.RenderView.PrepareInitialFrame();
@@ -99,10 +99,30 @@ public class WidgetBinding
         NeedsVisualUpdate = false;
 
         Pipeline?.FlushLayout();
+
+        // レイアウト結果サイズ = オーバーレイサイズ。変化していればレンダースレッドで GLView をリサイズする。
+        // 初回生成時だけでなく、MarkNeedsLayout 起点の再レイアウト（テキスト変更やホットリロード）でも
+        // FlushLayout 後にここで検知されるため、同じ経路でサイズ追従できる。
+        PostResizeIfSizeChanged();
+
         Pipeline?.FlushPaint();
 
         if (Pipeline?.RenderView.Layer?.Clone() is not ContainerLayer layer) return;
 
         RenderThreadRunner?.PostRender(Window, layer);
+    }
+
+    private void PostResizeIfSizeChanged()
+    {
+        var newSize = Pipeline?.RenderView.Size.ToSizeI() ?? SKSizeI.Empty;
+
+        if (newSize == _lastPostedSize || newSize is not { Width: > 0, Height: > 0 }) return;
+
+        _lastPostedSize = newSize;
+
+        var window = Window;
+        if (window == null) return;
+
+        RenderThreadRunner?.PostTask(() => window.Resize(newSize.Width, newSize.Height));
     }
 }

--- a/src/FloatSoda/Core/WindowKeyGenerator.cs
+++ b/src/FloatSoda/Core/WindowKeyGenerator.cs
@@ -1,21 +1,62 @@
-﻿using System.Reflection;
+using System.Reflection;
+using System.Text;
 
 namespace FloatSoda.Core;
 
-internal class WindowKeyGenerator
+/// <summary>
+/// オーバーレイキーの生成器。「エントリアセンブリ名（プロジェクトの名前空間）+ タイトル」を
+/// それぞれスネークケース化し、<c>.</c> でつないだものをキーとする。
+/// 例: アセンブリ <c>MyApp.Overlay</c> + タイトル <c>Watch DashBoard</c> → <c>my_app_overlay.watch_dash_board</c>
+/// </summary>
+internal static class WindowKeyGenerator
 {
-    private string _pattern = "";
-    
-    private static readonly string Endpoint = 
-        Assembly.GetEntryAssembly()?.GetName().Name ?? $"overlay_app.{Guid.NewGuid().ToString("N").ToLower()}";
+    private static readonly string Endpoint =
+        Assembly.GetEntryAssembly()?.GetName().Name ?? $"overlay_app_{Guid.NewGuid():N}";
 
-    public static string GenerateKey(string windowName)
+    public static string GenerateKey(string title) => $"{ToSnakeCase(Endpoint)}.{ToSnakeCase(title)}";
+
+    /// <summary>
+    /// PascalCase・スペース・ドット区切りをスネークケースへ変換する。
+    /// </summary>
+    internal static string ToSnakeCase(string text)
     {
-        var sanitizedEndPointName = Sanitized(Endpoint);
-        var sanitizedWindowName = Sanitized(windowName);
-        
-        return $"{sanitizedEndPointName}.{sanitizedWindowName}";
-    }
+        var builder = new StringBuilder(text.Length + 8);
 
-    private static string Sanitized(string text) => text.Replace(" ", "").Replace(".", "_").ToLower();
+        for (var i = 0; i < text.Length; i++)
+        {
+            var c = text[i];
+
+            if (char.IsUpper(c))
+            {
+                // 単語境界: 直前が小文字/数字、または大文字連続の末尾（次が小文字）
+                var isBoundary = i > 0 &&
+                                 (char.IsLower(text[i - 1]) || char.IsDigit(text[i - 1]) ||
+                                  (char.IsUpper(text[i - 1]) && i + 1 < text.Length && char.IsLower(text[i + 1])));
+
+                if (isBoundary && builder.Length > 0 && builder[^1] != '_')
+                {
+                    builder.Append('_');
+                }
+
+                builder.Append(char.ToLowerInvariant(c));
+            }
+            else if (char.IsLetterOrDigit(c))
+            {
+                builder.Append(c);
+            }
+            else if (builder.Length > 0 && builder[^1] != '_')
+            {
+                // スペース・ドット等の区切り文字はアンダースコアに畳む
+                builder.Append('_');
+            }
+        }
+
+        // 末尾の区切りを除去
+        if (builder.Length > 0 && builder[^1] == '_')
+        {
+            builder.Length--;
+        }
+
+        return builder.ToString();
+    }
 }

--- a/src/FloatSoda/Elements/InheritedElement.cs
+++ b/src/FloatSoda/Elements/InheritedElement.cs
@@ -16,7 +16,7 @@ public class InheritedElement : ComponentElement
             : [];
 
         // 祖先マップの有無にかかわらず自分自身を登録する（同型はネストした側で上書き＝最近傍が優先）
-        InheritedWidgets[Widget!.GetType()] = this;
+        InheritedWidgets[((InheritedWidget)Widget!).ScopeType] = this;
     }
 
     public void UpdateDependencies(Element dependent) => Dependents.Add(dependent);

--- a/src/FloatSoda/Elements/WindowElement.cs
+++ b/src/FloatSoda/Elements/WindowElement.cs
@@ -1,0 +1,34 @@
+using FloatSoda.RenderObjects;
+using FloatSoda.Widgets;
+
+namespace FloatSoda.Elements;
+
+/// <summary>
+/// <see cref="WindowWidget"/> の Element。マウント・更新時にウィンドウ宣言の
+/// <see cref="WindowWidget.Size"/> をルートの <see cref="RenderView.FixedSize"/> へ反映する。
+/// </summary>
+public class WindowElement : InheritedElement
+{
+    public override void Mount(Element? parent)
+    {
+        base.Mount(parent);
+        ApplySizeToRenderView();
+    }
+
+    public override void Update(Widget newWidget)
+    {
+        base.Update(newWidget);
+        ApplySizeToRenderView();
+    }
+
+    private void ApplySizeToRenderView()
+    {
+        for (var ancestor = Parent; ancestor != null; ancestor = ancestor.Parent)
+        {
+            if (ancestor is not RenderObjectElement { RenderObject: RenderView view }) continue;
+
+            view.FixedSize = (Widget as WindowWidget)?.Size;
+            return;
+        }
+    }
+}

--- a/src/FloatSoda/FloatSodaApp.cs
+++ b/src/FloatSoda/FloatSodaApp.cs
@@ -101,12 +101,12 @@ public class FloatSodaApp : IDisposable
     {
         _pendingTasks.Enqueue(() =>
         {
-            var windowName = window.WindowKey;
+            var title = window.Title;
             var widgetBinding = new WidgetBinding();
-            _bindings.TryAdd(windowName, widgetBinding);
-            widgetBinding.EnsureInitialized(windowName, _renderThreadRunner, _ => window.CreateOverlay(AppName));
+            _bindings.TryAdd(title, widgetBinding);
+            widgetBinding.EnsureInitialized(title, _renderThreadRunner, _ => window.CreateOverlay());
             widgetBinding.AttachRootWidget(window);
-            _logger?.LogInformation("{WindowName}を作成しました", windowName);
+            _logger?.LogInformation("{Title}を作成しました", title);
         });
     }
 

--- a/src/FloatSoda/FloatSodaApp.cs
+++ b/src/FloatSoda/FloatSodaApp.cs
@@ -7,6 +7,7 @@ using FloatSoda.OVR.Overlay;
 using FloatSoda.Widgets;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using OverlayWindow = FloatSoda.Widgets.OverlayWindow;
 
 namespace FloatSoda;
 
@@ -99,12 +100,18 @@ public class FloatSodaApp : IDisposable
     /// </summary>
     public void CreateWindow(WindowWidget window)
     {
+        // 現状はOpenVRオーバーレイのみ対応。デスクトップウィンドウ等は今後の派生で追加する。
+        if (window is not OverlayWindow overlayWindow)
+        {
+            throw new NotSupportedException($"{window.GetType().Name} は未対応のウィンドウ種別です。");
+        }
+
         _pendingTasks.Enqueue(() =>
         {
             var title = window.Title;
             var widgetBinding = new WidgetBinding();
             _bindings.TryAdd(title, widgetBinding);
-            widgetBinding.EnsureInitialized(title, _renderThreadRunner, _ => window.CreateOverlay());
+            widgetBinding.EnsureInitialized(title, _renderThreadRunner, _ => overlayWindow.CreateOverlay());
             widgetBinding.AttachRootWidget(window);
             _logger?.LogInformation("{Title}を作成しました", title);
         });

--- a/src/FloatSoda/FloatSodaApp.cs
+++ b/src/FloatSoda/FloatSodaApp.cs
@@ -7,7 +7,6 @@ using FloatSoda.OVR.Overlay;
 using FloatSoda.Widgets;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using SkiaSharp;
 
 namespace FloatSoda;
 
@@ -92,15 +91,21 @@ public class FloatSodaApp : IDisposable
         _logger?.LogInformation("ホットリロード: 全Widgetツリーを再ビルドします");
     }
 
-    public void CreateOverlayWindow(string windowName, Widget root, int width, int height,
-        Func<string, IOverlay> overlayFactory)
+    /// <summary>
+    /// ウィンドウ定義 <see cref="WindowWidget"/> からオーバーレイウィンドウを作成します。
+    /// <see cref="WindowWidget"/> はウィジェットツリーのルートとしてマウントされ、
+    /// <see cref="WindowWidget.Size"/> が null の場合、オーバーレイのサイズは
+    /// <see cref="InheritedWidget.Child"/> のレイアウト結果に追従します。
+    /// </summary>
+    public void CreateWindow(WindowWidget window)
     {
         _pendingTasks.Enqueue(() =>
         {
+            var windowName = window.WindowKey;
             var widgetBinding = new WidgetBinding();
             _bindings.TryAdd(windowName, widgetBinding);
-            widgetBinding.EnsureInitialized(windowName, new SKSize(width, height), _renderThreadRunner, overlayFactory);
-            widgetBinding.AttachRootWidget(root);
+            widgetBinding.EnsureInitialized(windowName, _renderThreadRunner, _ => window.CreateOverlay(AppName));
+            widgetBinding.AttachRootWidget(window);
             _logger?.LogInformation("{WindowName}を作成しました", windowName);
         });
     }

--- a/src/FloatSoda/FloatSodaAppExtensions.cs
+++ b/src/FloatSoda/FloatSodaAppExtensions.cs
@@ -1,7 +1,4 @@
-using System.Numerics;
 using FloatSoda.Engine;
-using FloatSoda.OVR.Overlay;
-using FloatSoda.Widgets;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace FloatSoda;
@@ -25,73 +22,5 @@ public static class FloatSodaAppExtensions
     {
         builder.Services.AddScoped<IFrameLimiter, OpenVRFrameLimiter>();
         return builder;
-    }
-
-    /// <summary>
-    /// SteamVR ダッシュボードに表示されるオーバーレイウィンドウを作成します。
-    /// </summary>
-    public static void CreateDashboardOverlay(
-        this FloatSodaApp app,
-        string windowName,
-        Widget root,
-        int width, int height)
-    {
-        app.CreateOverlayWindow(
-            windowName,
-            root,
-            width, height,
-            name => new DashboardOverlay(new DashboardOverlayIdentity($"{app.AppName.ToLower()}.{windowName.ToLower()}", windowName)));
-    }
-
-    /// <summary>
-    /// ワールド空間の指定座標に固定されたオーバーレイウィンドウを作成します。
-    /// </summary>
-    public static void CreateWorldSpaceOverlay(
-        this FloatSodaApp app,
-        string windowName,
-        Widget root,
-        int width, int height,
-        Vector3 position,
-        Quaternion? rotation = null)
-    {
-        app.CreateOverlayWindow(
-            windowName,
-            root,
-            width, height,
-            name =>
-            {
-                var overlay = new WorldSpaceOverlay(new OverlayIdentity($"{app.AppName.ToLower()}.{name.ToLower()}", name));
-                overlay.Transform.Position = position;
-                overlay.Transform.Rotation = rotation ?? Quaternion.Identity;
-                overlay.Visibility.Show();
-                return overlay;
-            });
-    }
-
-    /// <summary>
-    /// 指定したトラッキングデバイスに追従するオーバーレイウィンドウを作成します。
-    /// </summary>
-    public static void CreateTrackingOverlay(
-        this FloatSodaApp app,
-        string windowName,
-        Widget root,
-        int width, int height,
-        TrackedDevice target,
-        Vector3? offset = null,
-        Quaternion? rotation = null)
-    {
-        app.CreateOverlayWindow(
-            windowName,
-            root,
-            width, height,
-            name =>
-            {
-                var overlay = new DeviceTrackedOverlay(new OverlayIdentity($"{app.AppName.ToLower()}.{name.ToLower()}", name));
-                overlay.Transform.Target = target;
-                overlay.Transform.Position = offset ?? Vector3.Zero;
-                overlay.Transform.Rotation = rotation ?? Quaternion.Identity;
-                overlay.Visibility.Show();
-                return overlay;
-            });
     }
 }

--- a/src/FloatSoda/Geometrics/BoxConstraints.cs
+++ b/src/FloatSoda/Geometrics/BoxConstraints.cs
@@ -10,6 +10,12 @@ public readonly record struct BoxConstraints(
     double MinHeight = 0,
     double MaxHeight = PositiveInfinity)
 {
+    /// <summary>
+    /// 下限0・上限無限の完全に緩い制約。子はコンテンツサイズに収縮（shrink-wrap）します。
+    /// （<c>default(BoxConstraints)</c> は全て0になるため、無限上限が必要な場合はこれを使うこと）
+    /// </summary>
+    public static BoxConstraints Unbounded => new(0, PositiveInfinity, 0, PositiveInfinity);
+
     public static BoxConstraints Tight(SKSize size) => Tight(size.Width, size.Height);
 
     public static BoxConstraints Tight(double width, double height) => new(width, width, height, height);

--- a/src/FloatSoda/RenderObjects/RenderView.cs
+++ b/src/FloatSoda/RenderObjects/RenderView.cs
@@ -24,7 +24,7 @@ public class RenderView : RenderObject, IHasSingleChildRenderObject
         set => Child = (RenderBox?)value;
     }
 
-    public RenderView(float width, float height)
+    public RenderView(float width = 1000, float height = 1000)
     {
         Size = new SKSize(width, height);
         _child = new SingleChildContainer<RenderBox>(this);
@@ -32,7 +32,39 @@ public class RenderView : RenderObject, IHasSingleChildRenderObject
 
     public override bool IsRepaintBoundary => true;
 
-    public override void PerformLayout() => Child?.Layout(BoxConstraints.Tight(Size));
+    /// <summary>
+    /// ウィンドウの固定サイズ。null の場合は子のレイアウト結果サイズに追従します。
+    /// </summary>
+    public SKSize? FixedSize
+    {
+        get;
+        set
+        {
+            if (field == value) return;
+            field = value;
+            MarkNeedsLayout();
+        }
+    }
+
+    /// <summary>
+    /// <see cref="FixedSize"/> があれば Tight 制約でレイアウトし、なければ Loosen（無限上限）制約を
+    /// 渡して子ウィジェットのレイアウト結果サイズを <see cref="Size"/>（＝オーバーレイサイズ）に採用します。
+    /// </summary>
+    public override void PerformLayout()
+    {
+        if (Child == null)
+        {
+            Size = FixedSize ?? SKSize.Empty;
+            return;
+        }
+
+        var constraints = FixedSize is { } fixedSize
+            ? BoxConstraints.Tight(fixedSize)
+            : BoxConstraints.Unbounded;
+
+        Child.Layout(constraints, parentUseSize: true);
+        Size = FixedSize ?? Child.Size;
+    }
 
 
     public override void Paint(PaintingContext context, Offset offset)

--- a/src/FloatSoda/Widgets/InheritedWidget.cs
+++ b/src/FloatSoda/Widgets/InheritedWidget.cs
@@ -6,6 +6,12 @@ public abstract record InheritedWidget : Widget
 {
     public required Widget Child { get; init; }
 
+    /// <summary>
+    /// 祖先マップへの登録キー。既定は具象型（Flutter の ExactType セマンティクス）。
+    /// 基底型で lookup させたい階層（例: <see cref="WindowWidget"/>）はこれをオーバーライドする。
+    /// </summary>
+    public virtual Type ScopeType => GetType();
+
     public override Element CreateElement() => new InheritedElement() { Widget = this };
 
     public abstract bool UpdateShouldNotify(InheritedWidget oldWidget);

--- a/src/FloatSoda/Widgets/WindowWidget.cs
+++ b/src/FloatSoda/Widgets/WindowWidget.cs
@@ -1,0 +1,104 @@
+using System.Numerics;
+using FloatSoda.Elements;
+using FloatSoda.OVR.Overlay;
+using SkiaSharp;
+
+namespace FloatSoda.Widgets;
+
+/// <summary>
+/// ウィンドウ設定（種別・キー・ルート制約）を担うルートウィジェット。
+/// <see cref="IOverlay"/> の生成責務と、ウィンドウサイズの決定方法（<see cref="Size"/>）を宣言します。
+/// <see cref="FloatSodaApp.CreateWindow"/> に渡して使用します。
+/// </summary>
+public abstract record WindowWidget : InheritedWidget
+{
+    /// <summary>
+    /// オーバーレイを識別するウィンドウキー。<see cref="OverlayIdentity"/> のキー生成にも使用されます。
+    /// </summary>
+    public required string WindowKey { get; init; }
+
+    /// <summary>
+    /// ウィンドウの固定サイズ。null の場合は <see cref="Child"/> のレイアウト結果サイズに
+    /// ウィンドウサイズが追従します（Loosen）。指定するとそのサイズで子をレイアウトします（Tight）。
+    /// </summary>
+    public SKSize? Size { get; init; }
+
+    /// <summary>
+    /// 具象型によらず <see cref="WindowWidget"/> として lookup できるよう、基底型で登録する。
+    /// </summary>
+    public sealed override Type ScopeType => typeof(WindowWidget);
+
+    /// <summary>
+    /// 最も近い祖先の <see cref="WindowWidget"/> を取得し、依存関係を登録します。
+    /// </summary>
+    public static WindowWidget Of(IBuildContext context) =>
+        context.DependOnInheritedWidgetOfExactType<WindowWidget>() ??
+        throw new InvalidOperationException("WindowWidgetが祖先に見つかりません。");
+
+    public override bool UpdateShouldNotify(InheritedWidget oldWidget) => !Equals(oldWidget, this);
+
+    public override Element CreateElement() => new WindowElement { Widget = this };
+
+    /// <summary>
+    /// このウィンドウ定義に対応する <see cref="IOverlay"/> を生成します。レンダースレッド上で呼ばれます。
+    /// </summary>
+    /// <param name="appName">アプリ名。オーバーレイキーの接頭辞に使用されます。</param>
+    internal abstract IOverlay CreateOverlay(string appName);
+
+    private protected string BuildKey(string appName) => $"{appName.ToLower()}.{WindowKey.ToLower()}";
+}
+
+/// <summary>
+/// SteamVR ダッシュボードに表示されるウィンドウ。
+/// </summary>
+public record DashboardWindow : WindowWidget
+{
+    internal override IOverlay CreateOverlay(string appName)
+        => new DashboardOverlay(new DashboardOverlayIdentity(BuildKey(appName), WindowKey));
+}
+
+/// <summary>
+/// ワールド空間の指定座標に固定されるウィンドウ。
+/// </summary>
+public record WorldSpaceWindow : WindowWidget
+{
+    /// <summary>ワールド空間上の配置座標。</summary>
+    public required Vector3 Position { get; init; }
+
+    /// <summary>オーバーレイの回転。既定は無回転。</summary>
+    public Quaternion Rotation { get; init; } = Quaternion.Identity;
+
+    internal override IOverlay CreateOverlay(string appName)
+    {
+        var overlay = new WorldSpaceOverlay(new OverlayIdentity(BuildKey(appName), WindowKey));
+        overlay.Transform.Position = Position;
+        overlay.Transform.Rotation = Rotation;
+        overlay.Visibility.Show();
+        return overlay;
+    }
+}
+
+/// <summary>
+/// 指定したトラッキングデバイスに追従するウィンドウ。
+/// </summary>
+public record DeviceTrackedWindow : WindowWidget
+{
+    /// <summary>追従対象のトラッキングデバイス。</summary>
+    public required TrackedDevice Target { get; init; }
+
+    /// <summary>デバイス基準の位置オフセット。既定はゼロ。</summary>
+    public Vector3 Offset { get; init; } = Vector3.Zero;
+
+    /// <summary>オーバーレイの回転。既定は無回転。</summary>
+    public Quaternion Rotation { get; init; } = Quaternion.Identity;
+
+    internal override IOverlay CreateOverlay(string appName)
+    {
+        var overlay = new DeviceTrackedOverlay(new OverlayIdentity(BuildKey(appName), WindowKey));
+        overlay.Transform.Target = Target;
+        overlay.Transform.Position = Offset;
+        overlay.Transform.Rotation = Rotation;
+        overlay.Visibility.Show();
+        return overlay;
+    }
+}

--- a/src/FloatSoda/Widgets/WindowWidget.cs
+++ b/src/FloatSoda/Widgets/WindowWidget.cs
@@ -7,15 +7,15 @@ using SkiaSharp;
 namespace FloatSoda.Widgets;
 
 /// <summary>
-/// ウィンドウ設定（種別・タイトル・ルート制約）を担うルートウィジェット。
-/// <see cref="IOverlay"/> の生成責務と、ウィンドウサイズの決定方法（<see cref="Size"/>）を宣言します。
+/// ウィンドウ設定（タイトル・ルート制約）を担うルートウィジェットの基底。
+/// ウィンドウサイズの決定方法（<see cref="Size"/> による Tight / Loosen 制約）はこの基底が責務を持ち、
+/// 表示先（OpenVR オーバーレイ / 将来のデスクトップウィンドウ）は派生型が決めます。
 /// <see cref="FloatSodaApp.CreateWindow"/> に渡して使用します。
 /// </summary>
 public abstract record WindowWidget : InheritedWidget
 {
     /// <summary>
     /// ウィンドウに表示されるタイトル。SteamVR 上の表示名（ダッシュボードタブ名など）になります。
-    /// オーバーレイキーは「エントリアセンブリ名 + タイトルのスネークケース」から自動生成されます。
     /// </summary>
     public required string Title { get; init; }
 
@@ -40,19 +40,38 @@ public abstract record WindowWidget : InheritedWidget
     public override bool UpdateShouldNotify(InheritedWidget oldWidget) => !Equals(oldWidget, this);
 
     public override Element CreateElement() => new WindowElement { Widget = this };
+}
+
+/// <summary>
+/// OpenVR オーバーレイとして表示されるウィンドウの基底。
+/// <see cref="IOverlay"/> の生成責務とオーバーレイキーの管理はこの階層が持ちます
+/// （将来のデスクトップウィンドウはこの知識を持ちません）。
+/// </summary>
+public abstract record OverlayWindow : WindowWidget
+{
+    /// <summary>
+    /// 最も近い祖先の <see cref="OverlayWindow"/> を取得し、依存関係を登録します。
+    /// ルートがオーバーレイ以外のウィンドウの場合は例外をスローします。
+    /// </summary>
+    public new static OverlayWindow Of(IBuildContext context) =>
+        WindowWidget.Of(context) as OverlayWindow ??
+        throw new InvalidOperationException("OverlayWindowが祖先に見つかりません。");
 
     /// <summary>
     /// このウィンドウ定義に対応する <see cref="IOverlay"/> を生成します。レンダースレッド上で呼ばれます。
     /// </summary>
     internal abstract IOverlay CreateOverlay();
 
+    /// <summary>
+    /// OpenVR のオーバーレイキー。「エントリアセンブリ名 + <see cref="WindowWidget.Title"/> のスネークケース」から生成されます。
+    /// </summary>
     private protected string Key => WindowKeyGenerator.GenerateKey(Title);
 }
 
 /// <summary>
 /// SteamVR ダッシュボードに表示されるウィンドウ。
 /// </summary>
-public record DashboardWindow : WindowWidget
+public record DashboardWindow : OverlayWindow
 {
     internal override IOverlay CreateOverlay()
         => new DashboardOverlay(new DashboardOverlayIdentity(Key, Title));
@@ -61,7 +80,7 @@ public record DashboardWindow : WindowWidget
 /// <summary>
 /// ワールド空間の指定座標に固定されるウィンドウ。
 /// </summary>
-public record WorldSpaceWindow : WindowWidget
+public record WorldSpaceWindow : OverlayWindow
 {
     /// <summary>ワールド空間上の配置座標。</summary>
     public required Vector3 Position { get; init; }
@@ -82,7 +101,7 @@ public record WorldSpaceWindow : WindowWidget
 /// <summary>
 /// 指定したトラッキングデバイスに追従するウィンドウ。
 /// </summary>
-public record DeviceTrackedWindow : WindowWidget
+public record DeviceTrackedWindow : OverlayWindow
 {
     /// <summary>追従対象のトラッキングデバイス。</summary>
     public required TrackedDevice Target { get; init; }

--- a/src/FloatSoda/Widgets/WindowWidget.cs
+++ b/src/FloatSoda/Widgets/WindowWidget.cs
@@ -82,8 +82,11 @@ public record DashboardWindow : OverlayWindow
 /// </summary>
 public record WorldSpaceWindow : OverlayWindow
 {
-    /// <summary>ワールド空間上の配置座標。</summary>
-    public required Vector3 Position { get; init; }
+    /// <summary>
+    /// ワールド空間（Standing 原点 = プレイエリア床中央、前方 = -Z）上の配置座標。
+    /// 既定はプレイエリア中央から前方 1m・高さ 1m。
+    /// </summary>
+    public Vector3 Position { get; init; } = new(0f, 1f, -1f);
 
     /// <summary>オーバーレイの回転。既定は無回転。</summary>
     public Quaternion Rotation { get; init; } = Quaternion.Identity;

--- a/src/FloatSoda/Widgets/WindowWidget.cs
+++ b/src/FloatSoda/Widgets/WindowWidget.cs
@@ -1,4 +1,5 @@
 using System.Numerics;
+using FloatSoda.Core;
 using FloatSoda.Elements;
 using FloatSoda.OVR.Overlay;
 using SkiaSharp;
@@ -6,16 +7,17 @@ using SkiaSharp;
 namespace FloatSoda.Widgets;
 
 /// <summary>
-/// ウィンドウ設定（種別・キー・ルート制約）を担うルートウィジェット。
+/// ウィンドウ設定（種別・タイトル・ルート制約）を担うルートウィジェット。
 /// <see cref="IOverlay"/> の生成責務と、ウィンドウサイズの決定方法（<see cref="Size"/>）を宣言します。
 /// <see cref="FloatSodaApp.CreateWindow"/> に渡して使用します。
 /// </summary>
 public abstract record WindowWidget : InheritedWidget
 {
     /// <summary>
-    /// オーバーレイを識別するウィンドウキー。<see cref="OverlayIdentity"/> のキー生成にも使用されます。
+    /// ウィンドウに表示されるタイトル。SteamVR 上の表示名（ダッシュボードタブ名など）になります。
+    /// オーバーレイキーは「エントリアセンブリ名 + タイトルのスネークケース」から自動生成されます。
     /// </summary>
-    public required string WindowKey { get; init; }
+    public required string Title { get; init; }
 
     /// <summary>
     /// ウィンドウの固定サイズ。null の場合は <see cref="Child"/> のレイアウト結果サイズに
@@ -42,10 +44,9 @@ public abstract record WindowWidget : InheritedWidget
     /// <summary>
     /// このウィンドウ定義に対応する <see cref="IOverlay"/> を生成します。レンダースレッド上で呼ばれます。
     /// </summary>
-    /// <param name="appName">アプリ名。オーバーレイキーの接頭辞に使用されます。</param>
-    internal abstract IOverlay CreateOverlay(string appName);
+    internal abstract IOverlay CreateOverlay();
 
-    private protected string BuildKey(string appName) => $"{appName.ToLower()}.{WindowKey.ToLower()}";
+    private protected string Key => WindowKeyGenerator.GenerateKey(Title);
 }
 
 /// <summary>
@@ -53,8 +54,8 @@ public abstract record WindowWidget : InheritedWidget
 /// </summary>
 public record DashboardWindow : WindowWidget
 {
-    internal override IOverlay CreateOverlay(string appName)
-        => new DashboardOverlay(new DashboardOverlayIdentity(BuildKey(appName), WindowKey));
+    internal override IOverlay CreateOverlay()
+        => new DashboardOverlay(new DashboardOverlayIdentity(Key, Title));
 }
 
 /// <summary>
@@ -68,9 +69,9 @@ public record WorldSpaceWindow : WindowWidget
     /// <summary>オーバーレイの回転。既定は無回転。</summary>
     public Quaternion Rotation { get; init; } = Quaternion.Identity;
 
-    internal override IOverlay CreateOverlay(string appName)
+    internal override IOverlay CreateOverlay()
     {
-        var overlay = new WorldSpaceOverlay(new OverlayIdentity(BuildKey(appName), WindowKey));
+        var overlay = new WorldSpaceOverlay(new OverlayIdentity(Key, Title));
         overlay.Transform.Position = Position;
         overlay.Transform.Rotation = Rotation;
         overlay.Visibility.Show();
@@ -92,9 +93,9 @@ public record DeviceTrackedWindow : WindowWidget
     /// <summary>オーバーレイの回転。既定は無回転。</summary>
     public Quaternion Rotation { get; init; } = Quaternion.Identity;
 
-    internal override IOverlay CreateOverlay(string appName)
+    internal override IOverlay CreateOverlay()
     {
-        var overlay = new DeviceTrackedOverlay(new OverlayIdentity(BuildKey(appName), WindowKey));
+        var overlay = new DeviceTrackedOverlay(new OverlayIdentity(Key, Title));
         overlay.Transform.Target = Target;
         overlay.Transform.Position = Offset;
         overlay.Transform.Rotation = Rotation;

--- a/tests/FloatSoda.Test/Core/WindowKeyGeneratorTest.cs
+++ b/tests/FloatSoda.Test/Core/WindowKeyGeneratorTest.cs
@@ -1,0 +1,29 @@
+using FloatSoda.Core;
+
+namespace FloatSoda.Test.Core;
+
+public class WindowKeyGeneratorTest
+{
+    [Theory]
+    [InlineData("WatchDashBoard", "watch_dash_board")]
+    [InlineData("Left Hand", "left_hand")]
+    [InlineData("FloatSoda.Samples.OverlayApp", "float_soda_samples_overlay_app")]
+    [InlineData("OVRApp", "ovr_app")]
+    [InlineData("simple", "simple")]
+    [InlineData("My  Spaced   Title", "my_spaced_title")]
+    [InlineData("Version2Overlay", "version2_overlay")]
+    public void ToSnakeCase_ConvertsWordBoundaries(string input, string expected)
+    {
+        Assert.Equal(expected, WindowKeyGenerator.ToSnakeCase(input));
+    }
+
+    [Fact]
+    public void GenerateKey_JoinsEndpointAndTitleWithDot()
+    {
+        var key = WindowKeyGenerator.GenerateKey("My Dashboard");
+
+        // エンドポイント（エントリアセンブリ名）はテストホスト依存のため、形式のみ検証する
+        Assert.EndsWith(".my_dashboard", key);
+        Assert.Matches(@"^[a-z0-9_]+\.[a-z0-9_]+$", key);
+    }
+}

--- a/tests/FloatSoda.Test/RenderObjects/RenderViewTest.cs
+++ b/tests/FloatSoda.Test/RenderObjects/RenderViewTest.cs
@@ -1,0 +1,65 @@
+using FloatSoda.Core;
+using FloatSoda.Geometrics;
+using FloatSoda.RenderObjects;
+using FloatSoda.RenderObjects.Layout;
+using SkiaSharp;
+
+namespace FloatSoda.Test.RenderObjects;
+
+public class RenderViewTest
+{
+    private static (RenderView View, RenderPipeline Pipeline) Build(RenderBox child)
+    {
+        var view = new RenderView { Child = child };
+        var pipeline = new RenderPipeline
+        {
+            OnNeedVisualUpdate = () => { },
+            RenderView = view
+        };
+        view.PrepareInitialFrame();
+        return (view, pipeline);
+    }
+
+    [Fact]
+    public void Size_ShrinkWrapsToChild()
+    {
+        // Loosen(unbounded)制約により、RenderView.Size は子のレイアウト結果に収縮する。
+        var (view, pipeline) = Build(new RenderConstrainedBox
+        {
+            AdditionalConstraints = BoxConstraints.Tight(320, 240)
+        });
+
+        pipeline.FlushLayout();
+
+        Assert.Equal(new SKSize(320, 240), view.Size);
+    }
+
+    [Fact]
+    public void Size_FollowsChildSizeChange_ViaMarkNeedsLayout()
+    {
+        var box = new RenderConstrainedBox
+        {
+            AdditionalConstraints = BoxConstraints.Tight(100, 100)
+        };
+        var (view, pipeline) = Build(box);
+
+        pipeline.FlushLayout();
+        Assert.Equal(new SKSize(100, 100), view.Size);
+
+        // 子のサイズが変わると MarkNeedsLayout が RenderView まで伝播し、Size が追従する。
+        box.AdditionalConstraints = BoxConstraints.Tight(200, 150);
+        pipeline.FlushLayout();
+
+        Assert.Equal(new SKSize(200, 150), view.Size);
+    }
+
+    [Fact]
+    public void Size_IsEmpty_WhenNoChild()
+    {
+        var (view, pipeline) = Build(child: null!);
+
+        pipeline.FlushLayout();
+
+        Assert.True(view.Size.IsEmpty);
+    }
+}

--- a/tests/FloatSoda.Test/Widgets/WindowWidgetTest.cs
+++ b/tests/FloatSoda.Test/Widgets/WindowWidgetTest.cs
@@ -1,0 +1,89 @@
+using FloatSoda.Core;
+using FloatSoda.Elements;
+using FloatSoda.RenderObjects;
+using FloatSoda.Widgets;
+using FloatSoda.Widgets.Layout;
+using SkiaSharp;
+
+namespace FloatSoda.Test.Widgets;
+
+public class WindowWidgetTest
+{
+    /// <summary>Build時に祖先のWindowWidgetを探索して記録するプローブ。</summary>
+    private record Probe : StatelessWidget
+    {
+        public required Action<IBuildContext> OnBuild { get; init; }
+
+        public override Widget Build(IBuildContext context)
+        {
+            OnBuild(context);
+            return new SizedBox { Width = 10, Height = 10 };
+        }
+    }
+
+    private static (RenderPipeline Pipeline, RenderView RenderView) MountTree(Widget widget)
+    {
+        var renderView = new RenderView();
+        var pipeline = new RenderPipeline
+        {
+            OnNeedVisualUpdate = () => { },
+            RenderView = renderView
+        };
+        renderView.PrepareInitialFrame();
+
+        new RenderObjectToWidgetAdapter
+        {
+            Container = renderView,
+            Child = widget
+        }.AttachToRenderTree(new BuildOwner(() => { }), null);
+
+        return (pipeline, renderView);
+    }
+
+    [Fact]
+    public void Of_FindsConcreteWindow_ViaBaseTypeLookup()
+    {
+        WindowWidget? found = null;
+
+        MountTree(new DashboardWindow
+        {
+            WindowKey = "TestWindow",
+            Child = new Probe { OnBuild = ctx => found = WindowWidget.Of(ctx) }
+        });
+
+        // ScopeType により具象型（DashboardWindow）でも基底型 WindowWidget で lookup できる
+        Assert.IsType<DashboardWindow>(found);
+        Assert.Equal("TestWindow", found!.WindowKey);
+    }
+
+    [Fact]
+    public void SizeUnset_RenderViewShrinkWrapsToChild()
+    {
+        var (pipeline, renderView) = MountTree(new DashboardWindow
+        {
+            WindowKey = "TestWindow",
+            Child = new SizedBox { Width = 320, Height = 240 }
+        });
+
+        pipeline.FlushLayout();
+
+        Assert.Null(renderView.FixedSize);
+        Assert.Equal(new SKSize(320, 240), renderView.Size);
+    }
+
+    [Fact]
+    public void SizeSet_RenderViewUsesFixedSize()
+    {
+        var (pipeline, renderView) = MountTree(new DashboardWindow
+        {
+            WindowKey = "TestWindow",
+            Size = new SKSize(800, 600),
+            Child = new SizedBox { Width = 320, Height = 240 }
+        });
+
+        pipeline.FlushLayout();
+
+        Assert.Equal(new SKSize(800, 600), renderView.FixedSize);
+        Assert.Equal(new SKSize(800, 600), renderView.Size);
+    }
+}

--- a/tests/FloatSoda.Test/Widgets/WindowWidgetTest.cs
+++ b/tests/FloatSoda.Test/Widgets/WindowWidgetTest.cs
@@ -57,6 +57,21 @@ public class WindowWidgetTest
     }
 
     [Fact]
+    public void OverlayWindowOf_FindsConcreteOverlayWindow()
+    {
+        OverlayWindow? found = null;
+
+        MountTree(new DashboardWindow
+        {
+            Title = "TestWindow",
+            Child = new Probe { OnBuild = ctx => found = OverlayWindow.Of(ctx) }
+        });
+
+        // オーバーレイ系の中間基底 OverlayWindow でも lookup できる（Swap 拡張の前提）
+        Assert.IsType<DashboardWindow>(found);
+    }
+
+    [Fact]
     public void SizeUnset_RenderViewShrinkWrapsToChild()
     {
         var (pipeline, renderView) = MountTree(new DashboardWindow

--- a/tests/FloatSoda.Test/Widgets/WindowWidgetTest.cs
+++ b/tests/FloatSoda.Test/Widgets/WindowWidgetTest.cs
@@ -47,13 +47,13 @@ public class WindowWidgetTest
 
         MountTree(new DashboardWindow
         {
-            WindowKey = "TestWindow",
+            Title = "TestWindow",
             Child = new Probe { OnBuild = ctx => found = WindowWidget.Of(ctx) }
         });
 
         // ScopeType により具象型（DashboardWindow）でも基底型 WindowWidget で lookup できる
         Assert.IsType<DashboardWindow>(found);
-        Assert.Equal("TestWindow", found!.WindowKey);
+        Assert.Equal("TestWindow", found!.Title);
     }
 
     [Fact]
@@ -61,7 +61,7 @@ public class WindowWidgetTest
     {
         var (pipeline, renderView) = MountTree(new DashboardWindow
         {
-            WindowKey = "TestWindow",
+            Title = "TestWindow",
             Child = new SizedBox { Width = 320, Height = 240 }
         });
 
@@ -76,7 +76,7 @@ public class WindowWidgetTest
     {
         var (pipeline, renderView) = MountTree(new DashboardWindow
         {
-            WindowKey = "TestWindow",
+            Title = "TestWindow",
             Size = new SKSize(800, 600),
             Child = new SizedBox { Width = 320, Height = 240 }
         });


### PR DESCRIPTION
Closes #87

## 概要

オーバーレイの生成を `CreateOverlayWindow(windowName, root, width, height, overlayFactory)` の引数指定から、**Widget 側の宣言**へ移しました。議論の結果、issue の `AppWidget` 相当は **`WindowWidget`**（ウィンドウ設定 + ルート制約を持つ InheritedWidget）として実装しています。テーマ／ルーティング層（AppWidget）は導入しません。

```csharp
app.CreateWindow(new DashboardWindow
{
    Title = "WatchDashBoard",
    Child = new WatchWidget(),   // オーバーレイサイズは Child のレイアウト結果に追従
});
```

## 変更内容

### 1. WindowWidget（issue の 1. AppWidget 相当）
- `WindowWidget : InheritedWidget` が `Title` / `Size?` / `IOverlay` 生成責務を宣言的に保持
- 具象型: `DashboardWindow` / `WorldSpaceWindow` / `DeviceTrackedWindow`
- `InheritedWidget.ScopeType`（virtual、既定は具象型）を追加し、`WindowWidget` は基底型で祖先マップに登録 → 具象型によらず `WindowWidget.Of(context)` で参照可能
- 旧 `CreateDashboardOverlay` / `CreateWorldSpaceOverlay` / `CreateTrackingOverlay` 拡張メソッドと `width` / `height` 引数は廃止

### 2. ルートに Loosen 制約（issue の 2.）
- `RenderView.PerformLayout()` を `BoxConstraints.Tight(Size)` → `BoxConstraints.Unbounded` に変更し、子のレイアウト結果サイズを `RenderView.Size`（＝オーバーレイサイズ）に採用
- `WindowWidget.Size` 指定時は `RenderView.FixedSize` 経由で Tight 制約に切替（`WindowElement` が Mount/Update で反映）
- `BoxConstraints.Unbounded` を追加（`default(BoxConstraints)` は全ゼロになり `Loosen` では上限∞にならないため）

### 3. MarkNeedsLayout 起点のサイズ追従（issue の 3.）
- `WidgetBinding.DrawFrame()` の `FlushLayout()` 後にフレーム単位で `RenderView.Size` の変化を検知し、変化時のみレンダースレッドへ `Resize` をポスト
- ホットリロード（`Reassemble` → `BuildScope` → `FlushLayout`）によるサイズ変化も同じ経路で追従
- window type / key 自体の変更（オーバーレイ破棄・再生成）はスコープ外 → #90 で対応予定

### 4. GLView のリサイズ（issue の 4.）
- `GLView.Resize`: テクスチャ・`SKSurface` を破棄して再生成（同一サイズなら no-op）
- `TextureHandle` の変化は `OverlayWindow.Update()` が毎フレーム `FromTexture_t()` で登録し直すため追従


### 5. Title ベースのキー生成（レビュー中の変更）
- `WindowKey` を `Title` にリネーム。ウィンドウに表示されるタイトル（SteamVR 上の表示名）として扱う
- OpenVR のオーバーレイキーは「エントリアセンブリ名 + `Title` のスネークケース」をドットで連結して自動生成（例: `my_overlay_app.watch_dash_board`）。休眠していた `WindowKeyGenerator` を snake_case 対応に改修して活用


### 6. 中間基底 OverlayWindow の分離（レビュー中の変更）
- `WindowWidget`（基底）は `Title` / `Size` によるルート制約（Tight/Loosen）のみを担い、表示先の知識を持たない
- `OverlayWindow`（中間基底）が `IOverlay` 生成責務・オーバーレイキー管理・`OverlayWindow.Of(context)` を保持
- 将来の `DesktopWindow` は `WindowWidget` を直接継承でき、オーバーレイの知識を持たない。#90 の `Swap` 拡張は `OverlayWindow` を基底とする

## テスト

- `RenderViewTest`: shrink-wrap / MarkNeedsLayout 起点のサイズ追従 / 子なし
- `WindowWidgetTest`: 基底型 lookup（`Of`）/ `Size` 未指定時の追従 / `Size` 指定時の固定
- 全 108 テスト成功（`dotnet test`）

## 関連 issue

- #90 実行中のオーバーレイ種別切り替え（Swap）— 本PRの `WindowWidget` を前提に別対応

🤖 Generated with [Claude Code](https://claude.com/claude-code)

