### PR TITLE
fix: レンダースレッドのタスク例外隔離とデバイス未接続時の追従 (#92, #93)

### DIFF
--- a/src/FloatSoda.Engine/ThreadRunner.cs
+++ b/src/FloatSoda.Engine/ThreadRunner.cs
@@ -74,7 +74,29 @@ public abstract class ThreadRunner(string threadName, IFrameLimiter limiter, ILo
         }
     }
 
-    public abstract void PostTask(Action action);
+    private readonly ConcurrentQueue<Action> _pendingTasks = new();
+
+    public virtual void PostTask(Action action) => _pendingTasks.Enqueue(action);
+
+    /// <summary>
+    /// キューに積まれたタスクを実行する。1タスクが例外を投げても他のタスクとスレッド自体は継続する。
+    /// ここで拾わないと最上位の<see cref="RunLoop"/>のcatchまで抜けて<see cref="OnStop"/>が走り、
+    /// レンダースレッドが停止して以降すべての描画が止まる。
+    /// </summary>
+    protected void DrainPendingTasks()
+    {
+        while (_pendingTasks.TryDequeue(out var task))
+        {
+            try
+            {
+                task();
+            }
+            catch (Exception ex)
+            {
+                Logger?.LogError(ex, "{ThreadName} でタスクの実行に失敗しました", ThreadName);
+            }
+        }
+    }
 
     private void RunLoop(CancellationToken ct)
     {
@@ -129,9 +151,6 @@ public abstract class ThreadRunner(string threadName, IFrameLimiter limiter, ILo
 public class RenderThreadRunner(string threadName, IFrameLimiter limiter, ILogger? logger = null)
     : ThreadRunner(threadName, limiter, logger)
 {
-    private readonly ConcurrentQueue<Action> _pendingTasks = new();
-
-
     public void PostRender(IWindow window, ILayer layer)
     {
         PostTask(() =>
@@ -143,19 +162,7 @@ public class RenderThreadRunner(string threadName, IFrameLimiter limiter, ILogge
         });
     }
 
-    public override void PostTask(Action action)
-    {
-        _pendingTasks.Enqueue(action);
-    }
-
-
-    protected override void PreUpdate()
-    {
-        while (_pendingTasks.TryDequeue(out var task))
-        {
-            task();
-        }
-    }
+    protected override void PreUpdate() => DrainPendingTasks();
 
     protected override void OnStart(CancellationToken ct)
     {

--- a/src/FloatSoda.OVR/Overlay/Capability.cs
+++ b/src/FloatSoda.OVR/Overlay/Capability.cs
@@ -121,14 +121,30 @@ public sealed class WorldOverlayTransform(ulong overlayHandle) : OverlayTransfor
 public sealed class DeviceTrackedOverlayTransform(ulong overlayHandle) : OverlayTransform
 {
     public TrackedDevice Target { get; set; } = TrackedDevice.HMD;
-    
+
+    /// <summary>
+    /// <see cref="Target"/> が未接続のため直近の <see cref="Apply"/> を適用できなかったかどうか。
+    /// デバイス接続イベントで再度 <see cref="Apply"/> を呼び出す判断に使う。
+    /// </summary>
+    public bool PendingReapply { get; private set; }
+
     public override void Apply()
     {
+        var deviceIndex = TrackedDeviceResolver.ResolveIndex(Target);
+        if (deviceIndex == OpenVR.k_unTrackedDeviceIndexInvalid)
+        {
+            // Target未接続。例外にはせず、接続イベント（VREvent_TrackedDeviceActivated /
+            // VREvent_TrackedDeviceRoleChanged）を受けた再適用に委ねる。
+            PendingReapply = true;
+            return;
+        }
+
         var matrix = GetMatrix().ToHmdMatrix34_t();
         OpenVR.Overlay
-            .SetOverlayTransformTrackedDeviceRelative(overlayHandle, TrackedDeviceResolver.ResolveIndex(Target),
-                ref matrix)
+            .SetOverlayTransformTrackedDeviceRelative(overlayHandle, deviceIndex, ref matrix)
             .ThrowIfError();
+
+        PendingReapply = false;
     }
 }
 

--- a/src/FloatSoda/Core/WidgetBinding.cs
+++ b/src/FloatSoda/Core/WidgetBinding.cs
@@ -66,6 +66,20 @@ public class WidgetBinding
 
     public void EnsureVisualUpdate() => NeedsVisualUpdate = true;
 
+    /// <summary>
+    /// このウィンドウが <see cref="DeviceTrackedOverlayTransform"/> を持つ場合、Transform を再適用します。
+    /// デバイス接続/ロール変更イベント（VREvent_TrackedDeviceActivated / VREvent_TrackedDeviceRoleChanged）を
+    /// 受けて FloatSodaApp から呼ばれます。未接続だった場合の初回適用に加え、
+    /// 再接続で device index が変わったケースの再バインドも兼ねます（未接続なら Apply 側で安全にスキップされます）。
+    /// </summary>
+    public void ReapplyDeviceTrackedTransform()
+    {
+        if (Window is not OverlayWindow overlayWindow) return;
+        if (overlayWindow.Overlay is not IMovableOverlay { Transform: DeviceTrackedOverlayTransform transform }) return;
+
+        RenderThreadRunner?.PostTask(transform.Apply);
+    }
+
     public void AttachRootWidget(Widget rootWidget)
     {
         var isBootStrapFrame = RenderViewElement == null;

--- a/src/FloatSoda/FloatSodaApp.cs
+++ b/src/FloatSoda/FloatSodaApp.cs
@@ -190,6 +190,9 @@ public class FloatSodaApp : IDisposable
 
             _dispatcher.Register(EVREventType.VREvent_ProcessQuit, (in _) => _cts.Cancel());
 
+            // 起動時にコントローラーが未接続だったDeviceTrackedWindowへ、接続/ロール確定を機に再適用する。
+            _dispatcher.Register(EVREventType.VREvent_TrackedDeviceActivated, (in _) => ReapplyPendingDeviceTrackedTransforms());
+            _dispatcher.Register(EVREventType.VREvent_TrackedDeviceRoleChanged, (in _) => ReapplyPendingDeviceTrackedTransforms());
 
             _renderThreadRunner.Start(_cts.Token);
         }
@@ -206,6 +209,14 @@ public class FloatSodaApp : IDisposable
     }
 
     private void PollEvents() => _dispatcher?.PollEvents();
+
+    private void ReapplyPendingDeviceTrackedTransforms()
+    {
+        foreach (var (_, binding) in _bindings)
+        {
+            binding.ReapplyDeviceTrackedTransform();
+        }
+    }
 
 
     private void DrawFrame()

--- a/tests/FloatSoda.Test/Engine/ThreadRunnerTest.cs
+++ b/tests/FloatSoda.Test/Engine/ThreadRunnerTest.cs
@@ -1,0 +1,71 @@
+using FloatSoda.Engine;
+using Microsoft.Extensions.Logging;
+
+namespace FloatSoda.Test.Engine;
+
+public class ThreadRunnerTest
+{
+    private sealed class NoopFrameLimiter : IFrameLimiter
+    {
+        public void Wait() { }
+    }
+
+    /// <summary>ログに記録されたエラー件数を数えるだけのロガー。</summary>
+    private sealed class CountingLogger : ILogger
+    {
+        public int ErrorCount { get; private set; }
+
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            if (logLevel == LogLevel.Error) ErrorCount++;
+        }
+    }
+
+    /// <summary>GLFW を起動せずに <see cref="ThreadRunner.DrainPendingTasks"/> だけを検証するための最小サブクラス。</summary>
+    private sealed class TestThreadRunner(ILogger? logger)
+        : ThreadRunner("Test", new NoopFrameLimiter(), logger)
+    {
+        protected override void Update() { }
+
+        public void Drain() => DrainPendingTasks();
+    }
+
+    [Fact]
+    public void DrainPendingTasks_ThrowingTask_DoesNotStopSubsequentTasks()
+    {
+        var logger = new CountingLogger();
+        var runner = new TestThreadRunner(logger);
+
+        var ran = new List<int>();
+        runner.PostTask(() => ran.Add(1));
+        runner.PostTask(() => throw new InvalidOperationException("boom"));
+        runner.PostTask(() => ran.Add(2));
+
+        runner.Drain();
+
+        // 例外を投げたタスクの後続も実行され、失敗はログに記録される
+        Assert.Equal([1, 2], ran);
+        Assert.Equal(1, logger.ErrorCount);
+    }
+
+    [Fact]
+    public void DrainPendingTasks_ExecutesTasksInFifoOrder()
+    {
+        var runner = new TestThreadRunner(logger: null);
+
+        var order = new List<int>();
+        for (var i = 0; i < 5; i++)
+        {
+            var captured = i;
+            runner.PostTask(() => order.Add(captured));
+        }
+
+        runner.Drain();
+
+        Assert.Equal([0, 1, 2, 3, 4], order);
+    }
+}


### PR DESCRIPTION
Closes #92
Closes #93

## 概要

デバイス追従オーバーレイ（`DeviceTrackedWindow`）でコントローラーが未接続だと、生成処理が例外を投げ、**レンダースレッドごと停止して正常なウィンドウも含め全描画が止まる**問題を修正する。2つの根本原因（スレッド全滅・未接続の非許容）をそれぞれ対応。

## #92 レンダースレッドのタスク例外隔離

- `PostTask` で積まれたタスクの実行を1件ずつ try/catch で隔離。例外はログに記録してスレッドは継続する
- これがないと例外が `RunLoop` の最上位 catch まで抜けて `OnStop()`（`GLFW.Terminate()`）が走り、以降キューが消化されず全ウィンドウの描画が停止していた
- タスクキューと消化ループを `RenderThreadRunner` から `ThreadRunner` 基底へ集約し、`DrainPendingTasks()` として切り出した。GLFW 非依存でユニットテスト可能

## #93 デバイス未接続時の許容と再接続追従

- `DeviceTrackedOverlayTransform.Apply()`: `ResolveIndex` が `k_unTrackedDeviceIndexInvalid` の場合は OpenVR への適用をスキップし、例外を投げない（`PendingReapply` フラグを立てる）
- `FloatSodaApp` が `VREvent_TrackedDeviceActivated` / `VREvent_TrackedDeviceRoleChanged` を購読し、全ウィンドウの device-tracked Transform を再適用する
  - 起動時未接続だったウィンドウの初回適用に加え、**再接続で device index が変わったケースの再バインド**も兼ねる（未接続なら Apply 側で安全にスキップ）
  - 再適用は `RenderThreadRunner.PostTask` 経由でレンダースレッドに載せ、OpenVR 呼び出しスレッドを揃える

### 切断時の挙動

切断（`VREvent_TrackedDeviceDeactivated`）は今回スコープ外とし、放置（最後の相対 Transform のまま）とした。再接続時に上記の再適用で復帰する。非表示にする挙動が必要なら別途検討。

## テスト

- `ThreadRunnerTest`: 例外タスクの後続実行継続・FIFO 順序（GLFW 非依存の最小サブクラスで検証）
- 全 110 テスト成功（`dotnet test`）
- OpenVR 実機経路（`Apply` のスキップ／イベント再適用）は SteamVR 環境での動作確認が必要

🤖 Generated with [Claude Code](https://claude.com/claude-code)