### PR TITLE
docs(README): 英語サマリとバッジを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,13 @@
-# FloatSoda: SteamVR Overlay UI Framework (v0.0.2)
+# FloatSoda: SteamVR Overlay UI Framework
+
+[![NuGet](https://img.shields.io/nuget/v/FloatSoda.svg)](https://www.nuget.org/packages/FloatSoda/)
+[![NuGet Downloads](https://img.shields.io/nuget/dt/FloatSoda.svg)](https://www.nuget.org/packages/FloatSoda/)
+[![CI](https://github.com/sumx21t-3310/FloatSoda/actions/workflows/ci.yml/badge.svg)](https://github.com/sumx21t-3310/FloatSoda/actions/workflows/ci.yml)
+[![License: MIT](https://img.shields.io/github/license/sumx21t-3310/FloatSoda)](LICENSE)
+
+**FloatSoda** is a UI framework for building SteamVR overlays with a **Flutter-like declarative API** in C# / .NET. It renders via SkiaSharp → OpenGL → OpenVR, and manages multiple overlays (dashboard, world-space, and device-tracked) in a unified way. Currently in alpha — APIs may change without notice.
+
+> 📖 The documentation below is in Japanese. See the [Wiki](https://github.com/sumx21t-3310/FloatSoda/wiki) for details, or check the [minimal example](#最小構成のコード) — the code speaks for itself.
 
 **FloatSoda** は、SteamVR Overlay を **Flutter のような宣言的な書き心地** で作成できるように開発中の UI フレームワークです。SkiaSharp → OpenGL → OpenVR という経路でレンダリングし、複数のオーバーレイを統一的に管理できます。
 


### PR DESCRIPTION
## 目的

SEO 改善(英語圏の検索からの流入経路づくり)。GitHub/Google 検索で重視される README 冒頭に英語のプロジェクト説明を置く。

## 変更内容

- README 冒頭に英語サマリ(2文+日本語ドキュメントへの案内)を追加。日本語本文は無変更
- バッジ4種を追加: NuGet バージョン / NuGet ダウンロード数 / CI (ci.yml) / License (MIT)
- H1 の固定バージョン表記 `(v0.0.2)` を削除(62e7fc8 の方針に合わせたもの)

## 補足

リポジトリメタデータ(description / topics / homepage)も別途 `gh repo edit` で設定済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)