### PR TITLE
OpenVR native DLL を NuGet パッケージに含めるよう修正

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,3 +21,7 @@
 
 [Unreleased]: https://github.com/sumx21t-3310/FloatSoda/compare/v0.0.2...main
 [0.0.2]: https://github.com/sumx21t-3310/FloatSoda/releases/tag/v0.0.2
+
+
+## [0.0.3] - 2026-07-13
+- openvr_api.dllが正しく配置されるようにFloatSoda.OVR.csprojを変更

--- a/src/FloatSoda.OVR/FloatSoda.OVR.csproj
+++ b/src/FloatSoda.OVR/FloatSoda.OVR.csproj
@@ -10,10 +10,10 @@
 
 
   <ItemGroup>
-    <EmbeddedResource Include="openvr_api.dll">
-      <PackageCopyToOutput>true</PackageCopyToOutput>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </EmbeddedResource>
+    <None Include="openvr_api.dll"
+          Pack="true"
+          PackagePath="runtimes/win-x64/native/"
+          CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## 概要

`FloatSoda.OVR` の NuGet パッケージに `openvr_api.dll` が正しく含まれるよう修正しました。

これまで `openvr_api.dll` を `EmbeddedResource` として扱っていたため、パッケージには含まれていましたが、実行時に P/Invoke からロードできませんでした。

## 変更内容

* `openvr_api.dll` の配置方法を変更

  * `EmbeddedResource`
  * ↓
  * `runtimes/win-x64/native/openvr_api.dll`

* NuGet の native asset として配布されるよう `.csproj` を修正

## 背景

`OpenVR.Init()` 呼び出し時に以下のエラーが発生していました。

```
System.DllNotFoundException:
Unable to load DLL 'openvr_api'
```

原因は、NuGet パッケージからアプリケーションの実行環境へ `openvr_api.dll` が配置されていなかったためです。

.NET の NuGet ネイティブライブラリ配布規約に合わせて `runtimes/<RID>/native` 配下へ配置するよう変更しました。

## 確認項目

* [x] `dotnet pack` 後の `.nupkg` に `runtimes/win-x64/native/openvr_api.dll` が含まれることを確認
* [x] NuGet 参照側で native DLL が解決されることを確認
* [x] OpenVR 初期化が正常に実行できることを確認

## 影響範囲

`FloatSoda.OVR` を NuGet から利用しているアプリケーションで、OpenVR 初期化時の DLL ロード問題が解消されます。
