### PR TITLE
feat: OVRApplication.Identify() で自プロセスを SteamVR に登録

### DIFF
--- a/src/FloatSoda.OVR/OVRApplication.cs
+++ b/src/FloatSoda.OVR/OVRApplication.cs
@@ -115,8 +115,12 @@ public class OVRApplication : IDisposable
     /// <see cref="OpenVR.Init"/> only bootstraps the OpenVR API; it does not associate the
     /// calling process with a manifest's <c>app_key</c>. Call this once during startup — SteamVR
     /// needs the process/AppKey association for <see cref="AutoLaunch"/> and scene-transition
-    /// behavior to work correctly.
+    /// behavior to work correctly. Requires <see cref="Info"/>'s key to already be registered
+    /// with SteamVR (see <see cref="OVRApplications.AddManifest"/> and <see cref="Installed"/>);
+    /// otherwise this throws <see cref="Exceptions.VRApplicationException"/> with
+    /// <see cref="EVRApplicationError.UnknownApplication"/>.
     /// </remarks>
+    /// <exception cref="Exceptions.VRApplicationException">The application key is not registered with SteamVR, or another OpenVR application error occurred.</exception>
     public void Identify() =>
         OpenVR.Applications.IdentifyApplication((uint)Environment.ProcessId, Info.Key).ThrowIfError();
 

--- a/src/FloatSoda.OVR/OVRApplication.cs
+++ b/src/FloatSoda.OVR/OVRApplication.cs
@@ -108,6 +108,18 @@ public class OVRApplication : IDisposable
     /// <summary>Gets whether the application key is currently registered with SteamVR.</summary>
     public bool Installed => OpenVR.Applications.IsApplicationInstalled(Info.Key);
 
+    /// <summary>
+    /// Registers this process with SteamVR under <see cref="Info"/>'s application key.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="OpenVR.Init"/> only bootstraps the OpenVR API; it does not associate the
+    /// calling process with a manifest's <c>app_key</c>. Call this once during startup — SteamVR
+    /// needs the process/AppKey association for <see cref="AutoLaunch"/> and scene-transition
+    /// behavior to work correctly.
+    /// </remarks>
+    public void Identify() =>
+        OpenVR.Applications.IdentifyApplication((uint)Environment.ProcessId, Info.Key).ThrowIfError();
+
     /// <summary>Shuts down the process-wide OpenVR context.</summary>
     public void Dispose()
     {

--- a/src/FloatSoda/FloatSodaApp.cs
+++ b/src/FloatSoda/FloatSodaApp.cs
@@ -197,6 +197,7 @@ public class FloatSodaApp : IDisposable
         try
         {
             _openVR = new OVRApplication(_appInfo);
+            _openVR.Identify();
             _dispatcher = new VRSystemEventDispatcher();
 
             _dispatcher.Register(EVREventType.VREvent_Quit, (in _) =>

--- a/src/FloatSoda/FloatSodaApp.cs
+++ b/src/FloatSoda/FloatSodaApp.cs
@@ -197,7 +197,18 @@ public class FloatSodaApp : IDisposable
         try
         {
             _openVR = new OVRApplication(_appInfo);
-            _openVR.Identify();
+
+            try
+            {
+                _openVR.Identify();
+            }
+            catch (VRApplicationException e)
+            {
+                // マニフェスト未登録のAppKeyでも起動できるように、識別失敗は致命的エラーにしない
+                // (AutoLaunch/シーン遷移などマニフェスト連携機能のみが動作しなくなる)。
+                _logger?.LogWarning("SteamVRへのアプリケーション識別に失敗しました: {Message}", e.Message);
+            }
+
             _dispatcher = new VRSystemEventDispatcher();
 
             _dispatcher.Register(EVREventType.VREvent_Quit, (in _) =>


### PR DESCRIPTION
## Summary
- `OVRApplication.Identify()` を追加し、`IVRApplications::IdentifyApplication` をラップして自プロセス(`Environment.ProcessId`)と `Info.Key` を SteamVR に紐付ける
- `FloatSodaApp.Initialize()` で `OVRApplication` 生成直後に一度呼び出す

## Why
`OpenVR.Init` は OpenVR API を使えるようにするだけで、プロセスとマニフェストの `app_key` の関連付けは行わない。この関連付けが無いと `AutoLaunch` やシーン遷移などマニフェスト連携機能が正しく動作しない。#52 からの分割issue。

## Test plan
- [x] `dotnet build` — エラーなし(既存警告のみ)
- [x] `dotnet test tests/FloatSoda.Test` — 153 件成功
- [x] `dotnet test tests/FloatSoda.Common.Test` — 12 件成功

Closes #142