### PR TITLE
chore(release): v0.1.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
 
     <PropertyGroup>
-        <Version>0.0.3</Version>
+        <Version>0.1.0</Version>
     </PropertyGroup>
 
     <PropertyGroup>

--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ sequenceDiagram
 
 ---
 
-## 開発ステータス (v0.0.2 Alpha)
+## 開発ステータス (v0.1.0 Alpha)
 
 本プロジェクトは現在 **Alpha 段階** です。簡単なアプリケーションは動作しますが、API は予告なく変更されます。
 
@@ -184,9 +184,8 @@ sequenceDiagram
 - [x] レイヤーツリー（ContainerLayer / PictureLayer / ClipLayer / OpacityLayer）
 - [x] 複数オーバーレイ（ダッシュボード / ワールド座標 / デバイス追従）
 - [x] Widget → RenderObject への inflate パイプライン（StatelessWidget / StatefulWidget）
-- [x] BuildOwner による Widget 差分ビルド（子リストの差分更新を含む）
+- [x] BuildOwner による Widget 差分ビルド（Key による子リストの差分更新を含む）
 - [x] InheritedWidget によるコンテキスト伝播
-- [ ] Key による要素の同一性判定
+- [x] アニメーションシステム（AnimationController / Ticker / FadeTransition）
 - [ ] SteamVR のイベント処理と宣言的な入力（ヒットテスト）
-- [ ] アニメーションシステムの統合
 - [ ] マニフェストファイルの自動生成（検討中）

--- a/src/FloatSoda.Hooks/FloatSoda.Hooks.csproj
+++ b/src/FloatSoda.Hooks/FloatSoda.Hooks.csproj
@@ -4,6 +4,8 @@
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <!-- HookExtension未実装の実験段階のため、build loop統合(v0.5.0目安)までNuGet公開を停止 -->
+    <IsPackable>false</IsPackable>
     <PackageId>FloatSoda.Hooks</PackageId>
     <Description>React Hooks-style state management for FloatSoda widgets, built on R3 reactive properties. Experimental.</Description>
   </PropertyGroup>

--- a/src/FloatSoda.UI.Cream/FloatSoda.UI.Cream.csproj
+++ b/src/FloatSoda.UI.Cream/FloatSoda.UI.Cream.csproj
@@ -4,6 +4,8 @@
         <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
+        <!-- デザインシステム完成(v0.6.0)までNuGet公開を停止 -->
+        <IsPackable>false</IsPackable>
         <PackageId>FloatSoda.UI.Cream</PackageId>
         <Description>Cream design system for FloatSoda: retro, creamy color palettes and flat design. Maps FloatSoda.UI headless behavior widgets to styled visuals.</Description>
     </PropertyGroup>

--- a/src/FloatSoda.UI.FizzyPop/FloatSoda.UI.FizzyPop.csproj
+++ b/src/FloatSoda.UI.FizzyPop/FloatSoda.UI.FizzyPop.csproj
@@ -4,6 +4,8 @@
         <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
+        <!-- デザインシステム完成(v0.6.0)までNuGet公開を停止 -->
+        <IsPackable>false</IsPackable>
         <PackageId>FloatSoda.UI.FizzyPop</PackageId>
         <Description>FizzyPop design system for FloatSoda: translucent, glassmorphism-inspired visuals. Maps FloatSoda.UI headless behavior widgets to styled visuals.</Description>
     </PropertyGroup>

--- a/src/FloatSoda.UI/FloatSoda.UI.csproj
+++ b/src/FloatSoda.UI/FloatSoda.UI.csproj
@@ -4,6 +4,8 @@
         <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
+        <!-- ヒットテスト実装(v0.2.0)まで機能しないため、NuGet公開はデザインシステム完成(v0.6.0)まで停止 -->
+        <IsPackable>false</IsPackable>
         <PackageId>FloatSoda.UI</PackageId>
         <Description>Headless UI layer for FloatSoda. Provides behavior-only widgets (interaction state machines and typed builder slots) with no visual opinion, designed to be skinned by design-system packages such as FloatSoda.UI.Cream and FloatSoda.UI.FizzyPop.</Description>
     </PropertyGroup>


### PR DESCRIPTION
## 概要

**v0.1.0（初回正式リリース）**の準備コミットです。マージ後、main に `v0.1.0` タグを push すると release.yml が NuGet へ公開します。

## 変更内容

- `Directory.Build.props`: `0.0.3` → `0.1.0`（タグとの一致検証があるため必須）
- `README.md` 開発ステータス節の鮮度更新:
  - 見出し `v0.0.2` → `v0.1.0`
  - **アニメーションシステム**と **Key による子リスト差分**を実装済みにチェック（ジュニアコーダーテストで動作実証済み。この古い記述が以前 LLM 生成のプロジェクト要約を誤らせた実績あり → NuGet ページの顔なので初公開前に修正）

## リリースゲート状況（RELEASING.md）

- ✅ マイルストーン v0.1.0: open 0 / closed 14
- ✅ Release ビルド 0 エラー、テスト 165 件全パス（12 + 153）
- ✅ ジュニアコーダーテスト実施済み（本日、Sonnet 5・中）: docs のみで到達・ビルド可、実機表示確認。発見された ⓑ/ⓒ バグ 2 件は #149 で修正済み
- 📝 既知の残課題（ブロックしない判断）: #150（BGスレッド SetState、潜在リスク・実機では顕在化せず）、#151（物理サイズの発見性、docs）

🤖 Generated with [Claude Code](https://claude.com/claude-code)