### PR TITLE
docs: ジェスチャーAPIのドキュメントコメントを整備

### DIFF
--- a/samples/FloatSoda.Samples.OverlayApp/CounterWidget.cs
+++ b/samples/FloatSoda.Samples.OverlayApp/CounterWidget.cs
@@ -17,13 +17,20 @@ namespace FloatSoda.Samples.OverlayApp;
 /// </summary>
 public record CounterWidget : StatefulWidget<CounterWidget>
 {
+    /// <inheritdoc />
     public override State<CounterWidget> CreateState() => new CounterState();
 }
 
+/// <summary><see cref="CounterWidget"/>のカウント値を保持し、表示を構築します。</summary>
 public class CounterState : State<CounterWidget>
 {
+    /// <summary>画面に表示する現在のカウント値。</summary>
     private int _count = 0;
 
+    /// <summary>押下時に指定された処理を実行するカウンターボタンを構築します。</summary>
+    /// <param name="label">ボタンに表示する文字列。</param>
+    /// <param name="onPressed">ボタンがタップされたときに状態更新内で実行する処理。</param>
+    /// <returns>構築したボタンウィジェット。</returns>
     private Widget BuildButton(string label, Action onPressed)
     {
         return new GestureDetector
@@ -60,6 +67,7 @@ public class CounterState : State<CounterWidget>
         };
     }
 
+    /// <inheritdoc />
     public override Widget Build(IBuildContext context)
     {
         return new Align

--- a/samples/FloatSoda.Samples.OverlayApp/DragBoxWidget.cs
+++ b/samples/FloatSoda.Samples.OverlayApp/DragBoxWidget.cs
@@ -18,20 +18,27 @@ namespace FloatSoda.Samples.OverlayApp;
 /// </summary>
 public record DragBoxWidget : StatefulWidget<DragBoxWidget>
 {
+    /// <inheritdoc />
     public override State<DragBoxWidget> CreateState() => new DragBoxState();
 }
 
+/// <summary><see cref="DragBoxWidget"/>のドラッグ位置を保持し、表示を構築します。</summary>
 public class DragBoxState : State<DragBoxWidget>
 {
+    /// <summary>ドラッグ領域の一辺の長さ。単位は論理ピクセルです。</summary>
     private const float ContainerSize = 600f;
+
+    /// <summary>ドラッグ対象の一辺の長さ。単位は論理ピクセルです。</summary>
     private const float BoxSize = 140f;
 
-    // Align は子を remaining(= Container - Box) の範囲に -1..1 で配置する。
-    // よって delta(px) → alignment の変換係数は 2 / remaining。
+    /// <summary>ドラッグ領域からドラッグ対象を除いた移動可能距離。単位は論理ピクセルです。</summary>
+    /// <remarks>移動量を<see cref="Alignment"/>の-1から1の範囲へ変換するために使用します。</remarks>
     private const float Remaining = ContainerSize - BoxSize;
 
+    /// <summary>ドラッグ対象の現在の配置を保持します。</summary>
     private Alignment _alignment = Alignment.Center;
 
+    /// <inheritdoc />
     public override Widget Build(IBuildContext context)
     {
         return new Align

--- a/src/FloatSoda/Core/WidgetBinding.cs
+++ b/src/FloatSoda/Core/WidgetBinding.cs
@@ -258,6 +258,14 @@ public class WidgetBinding : IFrameScheduler, IHitTestTarget, IGestureBinding
         hitTestResult.Add(new HitTestEntry(this));
     }
     
+    /// <summary>
+    /// ヒットパスを通過したポインターイベントを認識器へ配送し、フェーズに応じてアリーナを進行します。
+    /// </summary>
+    /// <param name="pointerEvent">認識器へ配送するポインターイベント。</param>
+    /// <param name="entry">このバインディングに対応するヒットテストエントリ。</param>
+    /// <remarks>
+    /// Downフェーズでは認識器の参加受付を締め切り、Upフェーズでは未確定アリーナの既定勝者を確定します。
+    /// </remarks>
     public void HandleEvent(PointerEvent pointerEvent, HitTestEntry entry)
     {
         // ヒットパス末尾のこのエントリで、ジェスチャ認識器へのルーティングとアリーナ調停を行う

--- a/src/FloatSoda/Elements/ComponentElement.cs
+++ b/src/FloatSoda/Elements/ComponentElement.cs
@@ -47,6 +47,8 @@ public class StatefulElement<T> : ComponentElement where T : StatefulWidget<T>
     public State<T> State => _stateInternal!;
     private State<T>? _stateInternal = null;
     private bool _didChangeDependencies = false;
+
+    /// <summary><see cref="State{T}.Dispose"/>をすでに呼び出したかどうか。</summary>
     private bool _stateDisposed = false;
 
     public override void Mount(Element? parent)

--- a/src/FloatSoda/Gesture/GestureArena.cs
+++ b/src/FloatSoda/Gesture/GestureArena.cs
@@ -3,23 +3,25 @@ namespace FloatSoda.Gesture;
 /// <summary>アリーナでの勝敗の宣言。</summary>
 public enum GestureDisposition
 {
-    /// <summary>このポインタ列を自分のジェスチャとして受理する（勝利宣言）。</summary>
+    /// <summary>このポインター列を自分のジェスチャとして受理する（勝利宣言）。</summary>
     Accepted,
 
-    /// <summary>このポインタ列は自分のジェスチャではないと辞退する。</summary>
+    /// <summary>このポインター列は自分のジェスチャではないと辞退する。</summary>
     Rejected,
 }
 
 /// <summary>
-/// ジェスチャアリーナの参加者。1本のポインタを複数の認識器が奪い合うとき、
+/// ジェスチャアリーナの参加者。1本のポインターを複数の認識器が奪い合うとき、
 /// 勝敗が確定した時点で <see cref="AcceptGesture"/> / <see cref="RejectGesture"/> が呼ばれる。
 /// </summary>
 public interface IGestureArenaMember
 {
     /// <summary>このメンバーがアリーナの勝者になったとき呼ばれる。</summary>
+    /// <param name="pointer">勝敗が確定したポインターの識別子。</param>
     void AcceptGesture(int pointer);
 
     /// <summary>このメンバーが敗者になった（他が勝った/自分が辞退した）とき呼ばれる。</summary>
+    /// <param name="pointer">勝敗が確定したポインターの識別子。</param>
     void RejectGesture(int pointer);
 }
 
@@ -29,27 +31,39 @@ public interface IGestureArenaMember
 /// </summary>
 public sealed class GestureArenaEntry
 {
+    /// <summary>この参加を管理するジェスチャアリーナ。</summary>
     private readonly GestureArenaManager _arena;
+
+    /// <summary>この参加が属するポインターの識別子。</summary>
     private readonly int _pointer;
+
+    /// <summary>この参加に対応するアリーナメンバー。</summary>
     private readonly IGestureArenaMember _member;
 
+    /// <summary>ジェスチャアリーナへの参加を表すエントリを初期化します。</summary>
+    /// <param name="arena">参加を管理するジェスチャアリーナ。</param>
+    /// <param name="pointer">参加対象のポインター識別子。</param>
+    /// <param name="member">参加するアリーナメンバー。</param>
     internal GestureArenaEntry(GestureArenaManager arena, int pointer, IGestureArenaMember member)
         => (_arena, _pointer, _member) = (arena, pointer, member);
 
     /// <summary>このメンバーとして勝敗を宣言する。</summary>
+    /// <param name="disposition">宣言する受理または辞退の状態。</param>
     public void Resolve(GestureDisposition disposition)
         => _arena.Resolve(_pointer, _member, disposition);
 }
 
 /// <summary>
-/// ポインタごとにジェスチャ認識器を集め、勝者を1人に絞り込む調停器。Flutter の
+/// ポインターごとにジェスチャ認識器を集め、勝者を1人に絞り込む調停器。Flutter の
 /// <c>GestureArenaManager</c> に相当する。<see cref="Add"/> で参加、<see cref="Close"/> で
 /// 受付締切、<see cref="Sweep"/> で締切後の既定勝者確定を行う。
 /// </summary>
 public sealed class GestureArenaManager
 {
+    /// <summary>1本のポインターについて未確定の参加者と受付状態を保持します。</summary>
     private sealed class ArenaState
     {
+        /// <summary>現在アリーナに残っているメンバー。</summary>
         public readonly List<IGestureArenaMember> Members = [];
 
         /// <summary>まだ新規参加を受け付けているか（Down ディスパッチ中は true）。</summary>
@@ -59,9 +73,13 @@ public sealed class GestureArenaManager
         public IGestureArenaMember? EagerWinner;
     }
 
+    /// <summary>ポインター識別子ごとの未確定アリーナ。</summary>
     private readonly Dictionary<int, ArenaState> _arenas = [];
 
-    /// <summary>ポインタのアリーナにメンバーを参加させる。</summary>
+    /// <summary>ポインターのアリーナにメンバーを参加させる。</summary>
+    /// <param name="pointer">参加対象のポインター識別子。</param>
+    /// <param name="member">参加するジェスチャ認識器。</param>
+    /// <returns>参加したメンバーが勝敗を宣言するためのエントリ。</returns>
     public GestureArenaEntry Add(int pointer, IGestureArenaMember member)
     {
         if (!_arenas.TryGetValue(pointer, out var state))
@@ -78,6 +96,8 @@ public sealed class GestureArenaManager
     /// 新規参加の受付を締め切る（通常は Down のディスパッチ完了時）。
     /// メンバーが1人だけなら即座にそのメンバーを勝者にする。
     /// </summary>
+    /// <param name="pointer">受付を締め切るポインター識別子。</param>
+    /// <remarks>対象のアリーナが存在しない場合は何も行いません。</remarks>
     public void Close(int pointer)
     {
         if (!_arenas.TryGetValue(pointer, out var state)) return;
@@ -89,6 +109,8 @@ public sealed class GestureArenaManager
     /// <summary>
     /// 締切後も未確定なら、先頭メンバーを既定の勝者にする（通常は Up のディスパッチ時）。
     /// </summary>
+    /// <param name="pointer">勝者を確定するポインター識別子。</param>
+    /// <remarks>対象のアリーナを削除し、先頭以外の残存メンバーへ敗北を通知します。</remarks>
     public void Sweep(int pointer)
     {
         if (!_arenas.TryGetValue(pointer, out var state)) return;
@@ -105,6 +127,13 @@ public sealed class GestureArenaManager
     }
 
     /// <summary>メンバーからの勝敗宣言を処理する。</summary>
+    /// <param name="pointer">宣言対象のポインター識別子。</param>
+    /// <param name="member">勝敗を宣言するメンバー。</param>
+    /// <param name="disposition">宣言された受理または辞退の状態。</param>
+    /// <remarks>
+    /// 辞退したメンバーには直ちに敗北を通知します。受付中の受理は締切まで保留し、
+    /// 受付終了後の受理は宣言したメンバーを勝者としてアリーナを確定します。
+    /// </remarks>
     public void Resolve(int pointer, IGestureArenaMember member, GestureDisposition disposition)
     {
         if (!_arenas.TryGetValue(pointer, out var state)) return;
@@ -127,6 +156,9 @@ public sealed class GestureArenaManager
         }
     }
 
+    /// <summary>受付終了後の残存メンバー数と先行勝利宣言から勝敗を確定します。</summary>
+    /// <param name="pointer">確定対象のポインター識別子。</param>
+    /// <param name="state">確定対象のアリーナ状態。</param>
     private void TryToResolveArena(int pointer, ArenaState state)
     {
         switch (state.Members.Count)
@@ -144,6 +176,10 @@ public sealed class GestureArenaManager
         }
     }
 
+    /// <summary>指定したメンバーを勝者とし、ほかのメンバーへ敗北を通知します。</summary>
+    /// <param name="pointer">確定対象のポインター識別子。</param>
+    /// <param name="state">確定対象のアリーナ状態。</param>
+    /// <param name="member">勝者とするメンバー。</param>
     private void ResolveInFavorOf(int pointer, ArenaState state, IGestureArenaMember member)
     {
         _arenas.Remove(pointer);

--- a/src/FloatSoda/Gesture/GestureRecognizer.cs
+++ b/src/FloatSoda/Gesture/GestureRecognizer.cs
@@ -3,7 +3,7 @@ using FloatSoda.Abstractions.Input;
 namespace FloatSoda.Gesture;
 
 /// <summary>
-/// ポインタ列を監視し、それがタップ／ドラッグ等の意味あるジェスチャかを判定する状態機械の基底。
+/// ポインター列を監視し、それがタップ／ドラッグ等の意味あるジェスチャかを判定する状態機械の基底。
 /// <see cref="AddPointer"/> で Down を受けると、共有の <see cref="PointerRouter"/> へ後続イベントの
 /// 購読を登録し、<see cref="GestureArenaManager"/> のアリーナへ参加する。以降のイベントは
 /// ルータ経由で <see cref="HandleEvent"/> に届く。
@@ -17,6 +17,8 @@ public abstract class GestureRecognizer : IGestureArenaMember, IDisposable
     protected PointerRouter Router { get; private set; } = null!;
 
     /// <summary>ウィンドウの共有アリーナ／ルータを注入する。生成直後に一度だけ呼ばれる。</summary>
+    /// <param name="arena">認識器が参加するウィンドウ単位のジェスチャアリーナ。</param>
+    /// <param name="router">後続のポインターイベントを配送するルータ。</param>
     internal void Bind(GestureArenaManager arena, PointerRouter router)
     {
         Arena = arena;
@@ -27,6 +29,8 @@ public abstract class GestureRecognizer : IGestureArenaMember, IDisposable
     /// Down イベントを受けて監視を開始する入口。ルータ購読とアリーナ参加を行い、
     /// サブクラスの <see cref="AddAllowedPointer"/> を呼ぶ。
     /// </summary>
+    /// <param name="downEvent">監視を開始するDownフェーズのポインターイベント。</param>
+    /// <remarks>Down以外のイベントを指定した場合は何も行いません。</remarks>
     public void AddPointer(PointerEvent downEvent)
     {
         if (downEvent.Phase != PointerEventPhase.Down) return;
@@ -37,17 +41,22 @@ public abstract class GestureRecognizer : IGestureArenaMember, IDisposable
     }
 
     /// <summary>アリーナへ勝敗を宣言する。</summary>
+    /// <param name="pointer">勝敗を宣言するポインター識別子。</param>
+    /// <param name="disposition">宣言する受理または辞退の状態。</param>
     protected void Resolve(int pointer, GestureDisposition disposition)
         => Arena.Resolve(pointer, this, disposition);
 
-    /// <summary>このポインタの購読を解除する（勝敗確定後の後始末）。</summary>
+    /// <summary>このポインターの購読を解除する（勝敗確定後の後始末）。</summary>
+    /// <param name="pointer">購読を解除するポインター識別子。</param>
     protected void StopTrackingPointer(int pointer)
         => Router.RemoveRoute(pointer, HandleEvent);
 
     /// <summary>Down 受理時にサブクラスが初期状態を作る。</summary>
+    /// <param name="downEvent">受理したDownフェーズのポインターイベント。</param>
     protected abstract void AddAllowedPointer(PointerEvent downEvent);
 
     /// <summary>ルータ経由で届く後続イベント（Down/Move/Up）を処理する。</summary>
+    /// <param name="pointerEvent">処理するポインターイベント。</param>
     protected abstract void HandleEvent(PointerEvent pointerEvent);
 
     /// <inheritdoc />

--- a/src/FloatSoda/Gesture/GestureRecognizerFactory.cs
+++ b/src/FloatSoda/Gesture/GestureRecognizerFactory.cs
@@ -2,15 +2,17 @@ namespace FloatSoda.Gesture;
 
 /// <summary>
 /// 認識器インスタンスの生成と設定（コールバック注入）を分離するファクトリの基底。
-/// Widget は毎フレーム作り直されるため、rebuild を跨いで認識器インスタンスを温存しつつ
+/// Widgetは再構築のたびに作り直されるため、再構築をまたいで認識器インスタンスを温存しつつ
 /// コールバックだけ差し替えるためにこの分離が要る。
 /// </summary>
 public abstract class GestureRecognizerFactory
 {
     /// <summary>新しい認識器を生成する。</summary>
+    /// <returns>このファクトリが生成した未設定のジェスチャ認識器。</returns>
     public abstract GestureRecognizer ConstructRaw();
 
     /// <summary>既存／新規の認識器へコールバック等を設定する。</summary>
+    /// <param name="recognizer">このファクトリと同じ認識器型のインスタンス。</param>
     public abstract void InitializeRaw(GestureRecognizer recognizer);
 }
 
@@ -18,9 +20,13 @@ public abstract class GestureRecognizerFactory
 /// <typeparam name="T">生成する認識器の型。</typeparam>
 public sealed class GestureRecognizerFactory<T> : GestureRecognizerFactory where T : GestureRecognizer
 {
+    /// <summary>新しい認識器を生成するデリゲート。</summary>
     private readonly Func<T> _constructor;
+
+    /// <summary>認識器へ最新のコールバック設定を適用するデリゲート。</summary>
     private readonly Action<T> _initializer;
 
+    /// <summary>認識器の生成処理と初期化処理を指定してファクトリを初期化します。</summary>
     /// <param name="constructor">認識器を生成するデリゲート。</param>
     /// <param name="initializer">生成済み認識器へコールバックを設定するデリゲート。</param>
     public GestureRecognizerFactory(Func<T> constructor, Action<T> initializer)
@@ -29,7 +35,10 @@ public sealed class GestureRecognizerFactory<T> : GestureRecognizerFactory where
         _initializer = initializer;
     }
 
+    /// <inheritdoc />
     public override GestureRecognizer ConstructRaw() => _constructor();
 
+    /// <inheritdoc />
+    /// <exception cref="InvalidCastException"><paramref name="recognizer"/>が<typeparamref name="T"/>ではない場合。</exception>
     public override void InitializeRaw(GestureRecognizer recognizer) => _initializer((T)recognizer);
 }

--- a/src/FloatSoda/Gesture/HitTestBehaviour.cs
+++ b/src/FloatSoda/Gesture/HitTestBehaviour.cs
@@ -1,8 +1,14 @@
 ﻿namespace FloatSoda.Gesture;
 
+/// <summary>ポインターのヒットテストで自身と子要素をどのように扱うかを指定します。</summary>
 public enum HitTestBehaviour
 {
+    /// <summary>子要素がヒットした場合に限り、自身もヒットとして扱います。</summary>
     DeferToChild,
+
+    /// <summary>自身の領域全体をヒットとして扱い、背後の兄弟要素への探索を停止します。</summary>
     Opaque,
+
+    /// <summary>自身をヒットパスへ追加しつつ、背後の兄弟要素への探索を継続します。</summary>
     Translucent
 }

--- a/src/FloatSoda/Gesture/IGestureBinding.cs
+++ b/src/FloatSoda/Gesture/IGestureBinding.cs
@@ -10,6 +10,6 @@ public interface IGestureBinding
     /// <summary>このウィンドウのジェスチャアリーナ。</summary>
     GestureArenaManager GestureArena { get; }
 
-    /// <summary>このウィンドウのポインタルータ。</summary>
+    /// <summary>このウィンドウのポインタールータ。</summary>
     PointerRouter PointerRouter { get; }
 }

--- a/src/FloatSoda/Gesture/PointerRouter.cs
+++ b/src/FloatSoda/Gesture/PointerRouter.cs
@@ -3,15 +3,18 @@ using FloatSoda.Abstractions.Input;
 namespace FloatSoda.Gesture;
 
 /// <summary>
-/// ポインタIDごとに購読者を登録し、後続イベント（Down/Move/Up）を配送する。
+/// ポインター識別子ごとに購読者を登録し、後続イベント（Down/Move/Up）を配送する。
 /// 最初のヒットテストは Down 位置でしか行われないため、ドラッグ中に指がウィジェット外へ
 /// 出ても認識器へイベントを届け続けるための経路を担う。Flutter の <c>PointerRouter</c> に相当。
 /// </summary>
 public sealed class PointerRouter
 {
+    /// <summary>ポインター識別子ごとのイベント購読者。</summary>
     private readonly Dictionary<int, List<Action<PointerEvent>>> _routes = [];
 
-    /// <summary>ポインタに対する購読を追加する。</summary>
+    /// <summary>ポインターに対する購読を追加する。</summary>
+    /// <param name="pointer">購読対象のポインター識別子。</param>
+    /// <param name="route">イベントを受け取るコールバック。</param>
     public void AddRoute(int pointer, Action<PointerEvent> route)
     {
         if (!_routes.TryGetValue(pointer, out var list))
@@ -23,7 +26,10 @@ public sealed class PointerRouter
         list.Add(route);
     }
 
-    /// <summary>ポインタに対する購読を解除する。</summary>
+    /// <summary>ポインターに対する購読を解除する。</summary>
+    /// <param name="pointer">購読解除対象のポインター識別子。</param>
+    /// <param name="route">解除するコールバック。</param>
+    /// <remarks>最後の購読者を解除した場合は、ポインター識別子のエントリも削除します。</remarks>
     public void RemoveRoute(int pointer, Action<PointerEvent> route)
     {
         if (!_routes.TryGetValue(pointer, out var list)) return;
@@ -32,7 +38,9 @@ public sealed class PointerRouter
         if (list.Count == 0) _routes.Remove(pointer);
     }
 
-    /// <summary>イベントを、そのポインタの全購読者へ配送する。</summary>
+    /// <summary>イベントを、そのポインターの全購読者へ配送する。</summary>
+    /// <param name="pointerEvent">配送するポインターイベント。</param>
+    /// <remarks>配送開始時の購読者一覧を使用するため、コールバック内で購読を変更できます。</remarks>
     public void Route(PointerEvent pointerEvent)
     {
         if (!_routes.TryGetValue(pointerEvent.PointerId, out var list)) return;

--- a/src/FloatSoda/Gesture/Recognizers/PanGestureRecognizer.cs
+++ b/src/FloatSoda/Gesture/Recognizers/PanGestureRecognizer.cs
@@ -5,24 +5,32 @@ namespace FloatSoda.Gesture;
 
 /// <summary>
 /// ドラッグ（パン）を認識する。Down 後にスロップを超えて動いた時点でアリーナへ勝利を宣言し、
-/// 以降の移動量を <see cref="OnPanUpdate"/> に delta で通知する。
+/// 以降の移動量を<see cref="OnPanUpdate"/>へ前回位置との差分で通知する。
 /// </summary>
 public sealed class PanGestureRecognizer : GestureRecognizer
 {
     /// <summary>ドラッグ開始（勝利確定）時。引数は開始位置。</summary>
     public Action<Offset>? OnPanStart { get; set; }
 
-    /// <summary>ドラッグ中の移動。引数は前回からの delta。</summary>
+    /// <summary>ドラッグ中に、前回位置からの移動量を通知します。</summary>
     public Action<Offset>? OnPanUpdate { get; set; }
 
     /// <summary>ドラッグ終了時。</summary>
     public Action? OnPanEnd { get; set; }
 
+    /// <summary>現在のポインター列で押下が始まった位置。</summary>
     private Offset _initialPosition;
+
+    /// <summary>直前に移動量を通知した位置。</summary>
     private Offset _lastPosition;
+
+    /// <summary>ジェスチャアリーナがこの認識器を受理したかどうか。</summary>
     private bool _acceptedByArena;
+
+    /// <summary>移動量がしきい値を超え、ドラッグ開始を通知済みかどうか。</summary>
     private bool _started;
 
+    /// <inheritdoc />
     protected override void AddAllowedPointer(PointerEvent downEvent)
     {
         _initialPosition = downEvent.Position;
@@ -31,6 +39,7 @@ public sealed class PanGestureRecognizer : GestureRecognizer
         _started = false;
     }
 
+    /// <inheritdoc />
     protected override void HandleEvent(PointerEvent pointerEvent)
     {
         switch (pointerEvent.Phase)
@@ -73,11 +82,21 @@ public sealed class PanGestureRecognizer : GestureRecognizer
         }
     }
 
-    // アリーナ勝利は「ドラッグ資格の確定」まで。実際の開始(OnPanStart)はスロップ超過時に行う。
+    /// <inheritdoc />
+    /// <remarks>
+    /// アリーナでの勝利はドラッグ資格だけを確定します。
+    /// <see cref="OnPanStart"/>は移動量がしきい値を超えた時点で通知します。
+    /// </remarks>
     public override void AcceptGesture(int pointer) => _acceptedByArena = true;
 
+    /// <inheritdoc />
+    /// <remarks>対象ポインターのイベント購読を解除します。</remarks>
     public override void RejectGesture(int pointer) => StopTrackingPointer(pointer);
 
+    /// <summary>2点間のユークリッド距離を計算します。</summary>
+    /// <param name="a">一方の位置。</param>
+    /// <param name="b">もう一方の位置。</param>
+    /// <returns>2点間の距離。単位は論理ピクセルです。</returns>
     private static double Distance(Offset a, Offset b)
     {
         var dx = a.X - b.X;

--- a/src/FloatSoda/Gesture/Recognizers/TapGestureRecognizer.cs
+++ b/src/FloatSoda/Gesture/Recognizers/TapGestureRecognizer.cs
@@ -21,12 +21,22 @@ public sealed class TapGestureRecognizer : GestureRecognizer
     /// <summary>タップが不成立に終わったとき（他ジェスチャに敗北 / スロップ超過）。</summary>
     public Action? OnTapCancel { get; set; }
 
+    /// <summary>現在のポインター列で押下が始まった位置。</summary>
     private Offset _initialPosition;
+
+    /// <summary>ジェスチャアリーナがこの認識器を受理したかどうか。</summary>
     private bool _wonArena;
+
+    /// <summary>Upイベントを受信済みかどうか。</summary>
     private bool _receivedUp;
+
+    /// <summary><see cref="OnTap"/>を通知済みかどうか。</summary>
     private bool _fired;
+
+    /// <summary><see cref="OnTapCancel"/>を通知済みかどうか。</summary>
     private bool _canceled;
 
+    /// <inheritdoc />
     protected override void AddAllowedPointer(PointerEvent downEvent)
     {
         _initialPosition = downEvent.Position;
@@ -37,6 +47,7 @@ public sealed class TapGestureRecognizer : GestureRecognizer
         OnTapDown?.Invoke(downEvent.Position);
     }
 
+    /// <inheritdoc />
     protected override void HandleEvent(PointerEvent pointerEvent)
     {
         switch (pointerEvent.Phase)
@@ -60,14 +71,19 @@ public sealed class TapGestureRecognizer : GestureRecognizer
         }
     }
 
+    /// <inheritdoc />
     public override void AcceptGesture(int pointer)
     {
         _wonArena = true;
         CheckFire(pointer);
     }
 
+    /// <inheritdoc />
     public override void RejectGesture(int pointer) => Cancel(pointer);
 
+    /// <summary>タップを不成立として通知し、対象ポインターの購読を解除します。</summary>
+    /// <param name="pointer">購読を解除するポインター識別子。</param>
+    /// <remarks>すでに不成立を通知済みの場合は何も行いません。</remarks>
     private void Cancel(int pointer)
     {
         if (_canceled) return;
@@ -77,6 +93,8 @@ public sealed class TapGestureRecognizer : GestureRecognizer
         StopTrackingPointer(pointer);
     }
 
+    /// <summary>アリーナ勝利とUp受信がそろった場合にタップ成立を通知します。</summary>
+    /// <param name="pointer">成立後に購読を解除するポインター識別子。</param>
     private void CheckFire(int pointer)
     {
         if (_fired || _canceled || !_wonArena || !_receivedUp) return;
@@ -86,6 +104,10 @@ public sealed class TapGestureRecognizer : GestureRecognizer
         StopTrackingPointer(pointer);
     }
 
+    /// <summary>2点間のユークリッド距離を計算します。</summary>
+    /// <param name="a">一方の位置。</param>
+    /// <param name="b">もう一方の位置。</param>
+    /// <returns>2点間の距離。単位は論理ピクセルです。</returns>
     private static double Distance(Offset a, Offset b)
     {
         var dx = a.X - b.X;

--- a/src/FloatSoda/RenderObjects/Gesture/RenderAbsorbPointer.cs
+++ b/src/FloatSoda/RenderObjects/Gesture/RenderAbsorbPointer.cs
@@ -3,10 +3,20 @@ using FloatSoda.Gesture;
 
 namespace FloatSoda.RenderObjects.Gesture;
 
+/// <summary>
+/// 子要素の描画とレイアウトを維持したまま、ポインターのヒットを自身で吸収できるRenderObjectです。
+/// </summary>
+/// <seealso cref="Widgets.Gesture.AbsorbPointer"/>
 public class RenderAbsorbPointer : RenderProxyBox
 {
+    /// <summary>子要素へのヒットテストを遮断し、自身の領域でヒットを吸収するかどうかを取得または設定します。</summary>
+    /// <remarks>変更は次回のヒットテストから反映され、Layout DirtyまたはPaint Dirtyにはしません。</remarks>
     public bool Absorbing { get; set; }
 
+    /// <summary>吸収中は自身の領域内かだけを判定し、子要素をヒットパスへ追加しません。</summary>
+    /// <param name="result">ヒットした対象を格納する結果。</param>
+    /// <param name="position">このRenderObjectのローカル座標で表した判定位置。</param>
+    /// <returns>吸収中は位置が自身の領域内にある場合、それ以外は基底実装がヒットした場合に<see langword="true"/>。</returns>
     public override bool HitTest(HitTestResult result, Offset position)
     {
         return Absorbing ? Size.Contains(position) : base.HitTest(result, position);

--- a/src/FloatSoda/RenderObjects/Gesture/RenderIgnorePointer.cs
+++ b/src/FloatSoda/RenderObjects/Gesture/RenderIgnorePointer.cs
@@ -3,9 +3,19 @@ using FloatSoda.Gesture;
 
 namespace FloatSoda.RenderObjects.Gesture;
 
+/// <summary>
+/// 子要素の描画とレイアウトを維持したまま、自身を含む部分木をポインターのヒットテストから除外できるRenderObjectです。
+/// </summary>
+/// <seealso cref="Widgets.Gesture.IgnorePointer"/>
 public class RenderIgnorePointer : RenderProxyBox
 {
+    /// <summary>自身を含む部分木へのポインター入力を無視するかどうかを取得または設定します。</summary>
+    /// <remarks>変更は次回のヒットテストから反映され、Layout DirtyまたはPaint Dirtyにはしません。</remarks>
     public bool Ignoring { get; set; }
 
+    /// <summary>無視中は部分木を探索せず、常にヒットしなかったものとして扱います。</summary>
+    /// <param name="result">ヒットした対象を格納する結果。</param>
+    /// <param name="position">このRenderObjectのローカル座標で表した判定位置。</param>
+    /// <returns>無視中は常に<see langword="false"/>、それ以外は基底実装がヒットした場合に<see langword="true"/>。</returns>
     public override bool HitTest(HitTestResult result, Offset position) => !Ignoring && base.HitTest(result, position);
 }

--- a/src/FloatSoda/RenderObjects/Gesture/RenderPointerListener.cs
+++ b/src/FloatSoda/RenderObjects/Gesture/RenderPointerListener.cs
@@ -4,17 +4,35 @@ using FloatSoda.Gesture;
 
 namespace FloatSoda.RenderObjects.Gesture;
 
+/// <summary>ポインターイベントを受け取り、設定されたコールバックへ通知するRenderObjectです。</summary>
+/// <seealso cref="Widgets.Gesture.Listener"/>
 public class RenderPointerListener : RenderProxyBox
 {
+    /// <summary>ポインターが押されたときに呼び出すコールバックを取得または設定します。</summary>
     public Action<PointerEvent>? OnPointerDown { get; set; }
+
+    /// <summary>ポインターが離されたときに呼び出すコールバックを取得または設定します。</summary>
     public Action<PointerEvent>? OnPointerUp { get; set; }
+
+    /// <summary>ポインターが移動したときに呼び出すコールバックを取得または設定します。</summary>
     public Action<PointerEvent>? OnPointerMove { get; set; }
 
     /// <summary>ヒットテストでの振る舞い。空白領域を掴めるか／背後へ通すかを決める。</summary>
     public HitTestBehaviour Behaviour { get; set; } = HitTestBehaviour.DeferToChild;
 
+    /// <summary>不透明な振る舞いの場合に、自身の領域をヒット対象として扱います。</summary>
+    /// <param name="position">このRenderObjectのローカル座標で表した判定位置。</param>
+    /// <returns><see cref="Behaviour"/>が<see cref="HitTestBehaviour.Opaque"/>の場合に<see langword="true"/>。</returns>
     public override bool HitTestSelf(Offset position) => Behaviour == HitTestBehaviour.Opaque;
 
+    /// <summary><see cref="Behaviour"/>に従って自身と子要素をヒットテストします。</summary>
+    /// <param name="result">ヒットした対象を格納する結果。</param>
+    /// <param name="position">このRenderObjectのローカル座標で表した判定位置。</param>
+    /// <returns>自身または子要素が背後への探索を停止するヒットになった場合に<see langword="true"/>。</returns>
+    /// <remarks>
+    /// <see cref="HitTestBehaviour.Translucent"/>の場合は自身をヒットパスへ追加しますが、
+    /// 背後の兄弟要素の探索を継続するため、子要素がヒットしなければ<see langword="false"/>を返します。
+    /// </remarks>
     public override bool HitTest(HitTestResult result, Offset position)
     {
         if (!Size.Contains(position)) return false;
@@ -30,6 +48,10 @@ public class RenderPointerListener : RenderProxyBox
         return hit;
     }
 
+    /// <summary>イベントのフェーズに対応するポインターコールバックを呼び出します。</summary>
+    /// <param name="pointerEvent">処理するポインターイベント。</param>
+    /// <param name="entry">このRenderObjectに対応するヒットテストエントリ。</param>
+    /// <remarks>AddおよびRemoveフェーズではコールバックを呼び出しません。</remarks>
     public override void HandleEvent(PointerEvent pointerEvent, HitTestEntry entry)
     {
         var action = pointerEvent.Phase switch

--- a/src/FloatSoda/Widgets/Gesture/AbsorbPointer.cs
+++ b/src/FloatSoda/Widgets/Gesture/AbsorbPointer.cs
@@ -2,11 +2,17 @@
 
 namespace FloatSoda.Widgets.Gesture;
 
+/// <summary>子要素を描画したままポインター入力を自身で吸収し、子要素へ到達させないウィジェットです。</summary>
+/// <seealso cref="RenderAbsorbPointer"/>
 public record AbsorbPointer : SingleChildRenderObjectWidget<RenderAbsorbPointer>
 {
+    /// <summary>ポインターのヒットを吸収するかどうかを取得します。</summary>
+    /// <value>既定値は<see langword="true"/>です。</value>
     public bool Absorbing { get; init; } = true;
 
+    /// <inheritdoc />
     public override RenderAbsorbPointer CreateRenderObject() => new() { Absorbing = Absorbing };
 
+    /// <inheritdoc />
     public override void UpdateRenderObject(RenderAbsorbPointer renderObject) => renderObject.Absorbing = Absorbing;
 }

--- a/src/FloatSoda/Widgets/Gesture/GestureDetector.cs
+++ b/src/FloatSoda/Widgets/Gesture/GestureDetector.cs
@@ -10,6 +10,7 @@ namespace FloatSoda.Widgets.Gesture;
 /// </summary>
 public record GestureDetector : StatelessWidget
 {
+    /// <summary>ジェスチャを検出する対象の子ウィジェットを取得します。</summary>
     public required Widget Child { get; init; }
 
     /// <summary>ヒットテストでの振る舞い。空白領域を掴みたい場合は <see cref="HitTestBehaviour.Opaque"/>。</summary>
@@ -21,12 +22,15 @@ public record GestureDetector : StatelessWidget
     /// <summary>ドラッグ開始時。引数は開始位置。</summary>
     public Action<Offset>? OnPanStart { get; init; }
 
-    /// <summary>ドラッグ中の移動。引数は前回からの delta。</summary>
+    /// <summary>ドラッグ中に、前回位置からの移動量を通知するコールバックを取得します。</summary>
     public Action<Offset>? OnPanUpdate { get; init; }
 
     /// <summary>ドラッグ終了時。</summary>
     public Action? OnPanEnd { get; init; }
 
+    /// <summary>設定されたコールバックに対応する認識器ファクトリを構築します。</summary>
+    /// <param name="context">このウィジェットのビルドコンテキスト。</param>
+    /// <returns>認識器の所有とポインターイベントの橋渡しを行う<see cref="RawGestureDetector"/>。</returns>
     public override Widget Build(IBuildContext context)
     {
         var gestures = new Dictionary<Type, GestureRecognizerFactory>();
@@ -61,24 +65,31 @@ public record GestureDetector : StatelessWidget
 
 /// <summary>
 /// 認識器の集合を直接受け取り、内部 <see cref="Listener"/> の Down を各認識器へ橋渡しする低レベル層。
-/// 認識器インスタンスは rebuild を跨いで温存され、コールバックのみ差し替えられる。
+/// 認識器インスタンスは再構築をまたいで保持され、コールバックのみ差し替えられる。
 /// </summary>
 public record RawGestureDetector : StatefulWidget<RawGestureDetector>
 {
+    /// <summary>ジェスチャを検出する対象の子ウィジェットを取得します。</summary>
     public required Widget Child { get; init; }
 
+    /// <summary>ポインターのヒットテストで自身と子要素をどのように扱うかを取得します。</summary>
     public HitTestBehaviour Behaviour { get; init; } = HitTestBehaviour.DeferToChild;
 
+    /// <summary>認識器型ごとの生成処理と初期化処理を取得します。</summary>
+    /// <remarks>同じ型の認識器は再構築をまたいで再利用され、初期化処理だけが再実行されます。</remarks>
     public Dictionary<Type, GestureRecognizerFactory> Gestures { get; init; } = [];
 
+    /// <inheritdoc />
     public override State<RawGestureDetector> CreateState() => new RawGestureDetectorState();
 }
 
+/// <summary><see cref="RawGestureDetector"/>が所有する認識器のライフタイムと設定更新を管理します。</summary>
 internal class RawGestureDetectorState : State<RawGestureDetector>
 {
-    // ジェスチャ種別ごとに生存し続ける認識器インスタンス。
+    /// <summary>ジェスチャ種別ごとに再構築をまたいで保持する認識器インスタンス。</summary>
     private Dictionary<Type, GestureRecognizer> _recognizers = new();
 
+    /// <inheritdoc />
     public override Widget Build(IBuildContext context)
     {
         SyncAll(Widget!.Gestures);
@@ -123,6 +134,8 @@ internal class RawGestureDetectorState : State<RawGestureDetector>
         _recognizers = updated;
     }
 
+    /// <summary>Downイベントを現在のすべての認識器へ渡して監視を開始します。</summary>
+    /// <param name="downEvent">監視を開始するDownフェーズのポインターイベント。</param>
     private void HandlePointerDown(Abstractions.Input.PointerEvent downEvent)
     {
         foreach (var recognizer in _recognizers.Values)
@@ -131,6 +144,7 @@ internal class RawGestureDetectorState : State<RawGestureDetector>
         }
     }
 
+    /// <summary>所有するすべての認識器を破棄し、状態から取り除きます。</summary>
     public override void Dispose()
     {
         foreach (var recognizer in _recognizers.Values)

--- a/src/FloatSoda/Widgets/Gesture/IgnorePointer.cs
+++ b/src/FloatSoda/Widgets/Gesture/IgnorePointer.cs
@@ -2,11 +2,17 @@
 
 namespace FloatSoda.Widgets.Gesture;
 
+/// <summary>子要素を描画したまま、自身を含む部分木をポインターのヒットテストから除外するウィジェットです。</summary>
+/// <seealso cref="RenderIgnorePointer"/>
 public record IgnorePointer : SingleChildRenderObjectWidget<RenderIgnorePointer>
 {
+    /// <summary>自身を含む部分木へのポインター入力を無視するかどうかを取得します。</summary>
+    /// <value>既定値は<see langword="false"/>です。</value>
     public bool Ignoring { get; init; }
 
+    /// <inheritdoc />
     public override RenderIgnorePointer CreateRenderObject() => new() { Ignoring = Ignoring };
 
+    /// <inheritdoc />
     public override void UpdateRenderObject(RenderIgnorePointer renderObject) => renderObject.Ignoring = Ignoring;
 }

--- a/src/FloatSoda/Widgets/Gesture/Listener.cs
+++ b/src/FloatSoda/Widgets/Gesture/Listener.cs
@@ -4,15 +4,24 @@ using FloatSoda.RenderObjects.Gesture;
 
 namespace FloatSoda.Widgets.Gesture;
 
+/// <summary>子要素のヒット領域で発生した低レベルのポインターイベントを通知するウィジェットです。</summary>
+/// <remarks>タップやドラッグなどの意味付けが必要な場合は<see cref="GestureDetector"/>を使用します。</remarks>
+/// <seealso cref="RenderPointerListener"/>
 public record Listener : SingleChildRenderObjectWidget<RenderPointerListener>
 {
+    /// <summary>ポインターが押されたときに呼び出されるコールバックを取得します。</summary>
     public Action<PointerEvent>? OnPointerDown { get; init; }
+
+    /// <summary>ポインターが離されたときに呼び出されるコールバックを取得します。</summary>
     public Action<PointerEvent>? OnPointerUp { get; init; }
+
+    /// <summary>ポインターが移動したときに呼び出されるコールバックを取得します。</summary>
     public Action<PointerEvent>? OnPointerMove { get; init; }
 
     /// <summary>ヒットテストでの振る舞い。既定は子がヒットした時だけ反応する <see cref="HitTestBehaviour.DeferToChild"/>。</summary>
     public HitTestBehaviour Behaviour { get; init; } = HitTestBehaviour.DeferToChild;
 
+    /// <inheritdoc />
     public override RenderPointerListener CreateRenderObject()
     {
         return new RenderPointerListener()
@@ -24,6 +33,7 @@ public record Listener : SingleChildRenderObjectWidget<RenderPointerListener>
         };
     }
 
+    /// <inheritdoc />
     public override void UpdateRenderObject(RenderPointerListener renderObject)
     {
         renderObject.OnPointerDown = OnPointerDown;


### PR DESCRIPTION
## 概要

ジェスチャー層で追加されたAPIのXMLドキュメントコメントを、`docs/DocumentationComments.md`の規約に合わせて整備します。

## 変更内容

- ジェスチャーアリーナ、認識器、PointerRouterの引数・戻り値・副作用を明記
- `Listener`、`GestureDetector`、`AbsorbPointer`、`IgnorePointer`と対応するRenderObjectの契約を補完
- ヒットテスト、イベント購読解除、アリーナ確定、Dirty状態への影響を記載
- `<inheritdoc/>`、`<see>`、`<seealso>`による関連API参照を追加
- 関連サンプルの型・状態・内部メンバーのコメントを更新
- 入力語彙を「ポインター」に統一

## 目的と影響

IDEおよび生成されるAPI Referenceから、ジェスチャーAPIの役割・制約・観測可能な副作用を確認できるようにします。実行時の動作変更はありません。

## 検証

- `dotnet test FloatSoda.slnx --no-restore --nologo -v:minimal`（195件成功）
- `dotnet build FloatSoda.slnx --no-restore --nologo -v:minimal`（成功）
- 対象範囲のCS1591が0件であることを確認
- 追加した`cref`がすべて解決されることを確認
- `git diff --cached --check`

既存の別モジュールにあるCS1591警告と、PaintingSampleの`openvr_api`参照警告は本PRの対象外です。