### PR TITLE
docs: 基盤層のドキュメントコメントを整備(Abstractions/Widget/Element/RenderObject/Rendering/Engine)

### DIFF
--- a/src/FloatSoda.Abstractions/Engine/IEngineWindow.cs
+++ b/src/FloatSoda.Abstractions/Engine/IEngineWindow.cs
@@ -3,16 +3,22 @@ using FloatSoda.Rendering.Layers;
 
 namespace FloatSoda.Abstractions.Engine;
 
+/// <summary>レイヤーツリーの描画先と、その描画先に関連付けられたポインター入力を表します。</summary>
+/// <seealso cref="ILayer"/>
+/// <seealso cref="IRawPointerSource"/>
 public interface IEngineWindow : IDisposable
 {
     /// <summary>
     /// 指定されたレイヤーツリーをウィンドウの描画先へ反映します。
     /// </summary>
+    /// <param name="layer">反映するレイヤーツリー。<see langword="null"/>は指定できません。</param>
+    /// <remarks>描画先を所有するレンダースレッド上で呼び出します。</remarks>
     void Present(ILayer layer);
 
     /// <summary>
     /// 描画先テクスチャ／サーフェスのサイズを変更します。レンダースレッド上で呼ぶ必要があります。
     /// </summary>
+    /// <param name="size">変更後のピクセルサイズ。幅と高さには0より大きい値を指定します。</param>
     void Resize(SkiaSharp.SKSizeI size);
 
     /// <summary>

--- a/src/FloatSoda.Abstractions/Geometries/GeometryExtension.cs
+++ b/src/FloatSoda.Abstractions/Geometries/GeometryExtension.cs
@@ -1,9 +1,15 @@
-﻿using SkiaSharp;
+using SkiaSharp;
 
 namespace FloatSoda.Abstractions.Geometries;
 
+/// <summary>幾何型の移動および範囲判定を補助する拡張メソッドを提供します。</summary>
 public static class GeometryExtension
 {
+    /// <summary>角の半径を維持したまま、丸角矩形を指定量だけ移動した新しい値を作成します。</summary>
+    /// <param name="roundRect">移動元の丸角矩形。このオブジェクト自体は変更されません。</param>
+    /// <param name="dx">水平方向の移動量。単位は丸角矩形の座標系に従います。</param>
+    /// <param name="dy">垂直方向の移動量。単位は丸角矩形の座標系に従います。</param>
+    /// <returns>指定量だけ移動し、元と同じ角半径を持つ丸角矩形。</returns>
     public static SKRoundRect MakeOffset(this SKRoundRect roundRect, float dx, float dy)
     {
         var rect = roundRect.Rect;
@@ -15,9 +21,17 @@ public static class GeometryExtension
         return copy;
     }
 
+    /// <summary>角の半径を維持したまま、丸角矩形を指定量だけ移動した新しい値を作成します。</summary>
+    /// <param name="roundRect">移動元の丸角矩形。このオブジェクト自体は変更されません。</param>
+    /// <param name="offset">水平および垂直方向の移動量。単位は丸角矩形の座標系に従います。</param>
+    /// <returns>指定量だけ移動し、元と同じ角半径を持つ丸角矩形。</returns>
     public static SKRoundRect MakeOffset(this SKRoundRect roundRect, Offset offset) =>
         roundRect.MakeOffset((float)offset.X, (float)offset.Y);
 
+    /// <summary>原点を左上とするサイズの範囲内に指定座標が含まれるかを判定します。</summary>
+    /// <param name="size">判定する範囲の幅と高さ。</param>
+    /// <param name="offset">判定する座標。単位はサイズと同じである必要があります。</param>
+    /// <returns>座標が左端と上端を含み、右端と下端を含まない範囲内なら<see langword="true"/>、それ以外は<see langword="false"/>。</returns>
     public static bool Contains(this SKSize size, Offset offset)
     {
         return offset.X >= 0 && offset.X < size.Width && offset.Y >= 0 && offset.Y < size.Height;

--- a/src/FloatSoda.Abstractions/Geometries/Offset.cs
+++ b/src/FloatSoda.Abstractions/Geometries/Offset.cs
@@ -1,23 +1,60 @@
-﻿using SkiaSharp;
+using SkiaSharp;
 
 namespace FloatSoda.Abstractions.Geometries;
 
+/// <summary>二次元座標または移動量を倍精度の成分で表します。</summary>
+/// <param name="X">水平方向の成分。単位は利用する座標系に従い、既定値は0です。</param>
+/// <param name="Y">垂直方向の成分。単位は利用する座標系に従い、既定値は0です。</param>
+/// <seealso cref="SKPoint"/>
 public readonly record struct Offset(double X = 0, double Y = 0)
 {
+    /// <summary>両方の成分が0の座標または移動量を取得します。</summary>
     public static Offset Zero => default;
+    /// <summary>両方の成分が1の座標または移動量を取得します。</summary>
     public static Offset One => new(1, 1);
 
+    /// <summary>二つの値の対応する成分を加算します。</summary>
+    /// <param name="a">加算される値。</param>
+    /// <param name="b">加算する値。</param>
+    /// <returns>両方の値の対応する成分を加算した結果。</returns>
     public static Offset operator +(Offset a, Offset b) => new(a.X + b.X, a.Y + b.Y);
 
+    /// <summary>一つ目の値から二つ目の値の対応する成分を減算します。</summary>
+    /// <param name="a">減算される値。</param>
+    /// <param name="b">減算する値。</param>
+    /// <returns>一つ目の値から二つ目の値の対応する成分を減算した結果。</returns>
     public static Offset operator -(Offset a, Offset b) => new(a.X - b.X, a.Y - b.Y);
+    /// <summary>各成分の符号を反転します。</summary>
+    /// <param name="a">符号を反転する値。</param>
+    /// <returns>各成分の符号を反転した結果。</returns>
     public static Offset operator -(Offset a) => new(-a.X, -a.Y);
 
+    /// <summary>各成分を指定された倍率で拡大または縮小します。</summary>
+    /// <param name="a">拡大または縮小する値。</param>
+    /// <param name="b">各成分に乗算する倍率。</param>
+    /// <returns>各成分に倍率を乗算した結果。</returns>
     public static Offset operator *(Offset a, double b) => new(a.X * b, a.Y * b);
+    /// <summary>指定された倍率で各成分を拡大または縮小します。</summary>
+    /// <param name="a">各成分に乗算する倍率。</param>
+    /// <param name="b">拡大または縮小する値。</param>
+    /// <returns>各成分に倍率を乗算した結果。</returns>
     public static Offset operator *(double a, Offset b) => b * a;
 
+    /// <summary>各成分を指定された除数で除算します。</summary>
+    /// <param name="a">除算する値。</param>
+    /// <param name="b">各成分を除算する除数。</param>
+    /// <returns>各成分を除数で除算した結果。</returns>
+    /// <remarks>除数が0の場合の結果は倍精度浮動小数点数の除算規則に従います。</remarks>
     public static Offset operator /(Offset a, double b) => new(a.X / b, a.Y / b);
 
+    /// <summary><see cref="SKPoint"/>を同じ成分の値へ変換します。</summary>
+    /// <param name="point">変換する単精度の座標。</param>
+    /// <returns>各成分を倍精度で保持する変換結果。</returns>
     public static implicit operator Offset(SKPoint point) => new(point.X, point.Y);
-    
+
+    /// <summary>値を同じ成分の<see cref="SKPoint"/>へ変換します。</summary>
+    /// <param name="offset">変換する倍精度の座標または移動量。</param>
+    /// <returns>各成分を単精度へ変換した座標。</returns>
+    /// <remarks>各成分は単精度へ変換されるため、精度が低下する場合があります。</remarks>
     public static implicit operator SKPoint(Offset offset) => new ((float)offset.X, (float)offset.Y);
 }

--- a/src/FloatSoda.Abstractions/Input/PointerController.cs
+++ b/src/FloatSoda.Abstractions/Input/PointerController.cs
@@ -23,6 +23,8 @@ public class PointerController : IDisposable
     /// <summary>変換済みポインタイベントの通知。<see cref="Flush"/> を呼んだスレッドで発火します。</summary>
     public event Action<PointerEvent>? OnPointerEvent;
 
+    /// <summary>指定された生ポインター入力源を購読するコントローラーを作成します。</summary>
+    /// <param name="pointerSource">購読する生ポインター入力源。<see langword="null"/>は指定できず、破棄するまで保持されます。</param>
     public PointerController(IRawPointerSource pointerSource)
     {
         _pointerSource = pointerSource;
@@ -138,6 +140,8 @@ public class PointerController : IDisposable
         }
     }
 
+    /// <summary>生ポインター入力源の購読を解除し、以後に発生するイベントの受信を停止します。</summary>
+    /// <remarks>破棄前にキューへ追加済みのイベントは削除されず、その後の<see cref="Flush"/>で通知されます。</remarks>
     public void Dispose()
     {
         _pointerSource.OnPointerEvent -= Enqueue;

--- a/src/FloatSoda.Abstractions/Input/PointerEvent.cs
+++ b/src/FloatSoda.Abstractions/Input/PointerEvent.cs
@@ -1,16 +1,29 @@
-﻿using FloatSoda.Abstractions.Geometries;
+using FloatSoda.Abstractions.Geometries;
 
 namespace FloatSoda.Abstractions.Input;
 
+/// <summary>ポインターイベントのライフサイクル上の段階を表します。</summary>
+/// <seealso cref="PointerEvent"/>
 public enum PointerEventPhase
 {
+    /// <summary>ポインターの主ボタンが離された段階です。</summary>
     Up,
+    /// <summary>ポインターの主ボタンが押された段階です。</summary>
     Down,
+    /// <summary>押下中のポインターが移動した段階です。</summary>
     Move,
+    /// <summary>新しいポインターが入力領域へ追加された段階です。</summary>
     Add,
+    /// <summary>ポインターが入力領域から削除された段階です。</summary>
     Remove
 };
 
+/// <summary>正規化されたポインター入力を識別子、段階、および座標とともに表します。</summary>
+/// <param name="PointerId">同じポインターの追加から削除までを識別する番号。</param>
+/// <param name="Phase">ポインターイベントのライフサイクル上の段階。</param>
+/// <param name="Position">イベント発生位置。単位と原点はイベントを生成した入力領域の座標系に従います。</param>
+/// <param name="Transform">イベントに関連付ける任意の座標変換量。指定しない場合は<see langword="null"/>です。</param>
+/// <seealso cref="PointerController"/>
 public readonly record struct PointerEvent(
     int PointerId,
     PointerEventPhase Phase,

--- a/src/FloatSoda.Abstractions/Scheduling/IFramePacer.cs
+++ b/src/FloatSoda.Abstractions/Scheduling/IFramePacer.cs
@@ -1,9 +1,11 @@
 ﻿namespace FloatSoda.Abstractions.Scheduling;
 
+/// <summary>フレーム間隔を調整するための待機処理を提供します。</summary>
 public interface IFramePacer
 {
     /// <summary>
     /// 次のフレーム時刻まで待機します。
     /// </summary>
+    /// <param name="cancellationToken">待機を中断するためのトークン。既定値では中断を要求しません。</param>
     void WaitForNextFrame(CancellationToken cancellationToken = default);
 }

--- a/src/FloatSoda.Engine/DesktopWindow.cs
+++ b/src/FloatSoda.Engine/DesktopWindow.cs
@@ -7,11 +7,19 @@ using SkiaSharp;
 
 namespace FloatSoda.Engine;
 
+/// <summary>
+/// GLFW の可視ウィンドウへレイヤーツリーを表示するデスクトップ向けエンジンウィンドウです。
+/// 描画結果を既定のフレームバッファへ転送し、ウィンドウ固有のポインター入力を提供します。
+/// </summary>
 public class DesktopWindow : IEngineWindow
 {
     private readonly Renderer renderer;
     private int _blitFbo;
 
+    /// <summary>
+    /// 指定したレンダラーの GLFW ウィンドウを表示先として使用するインスタンスを初期化します。
+    /// </summary>
+    /// <param name="renderer">描画と GLFW ウィンドウの管理に使用するレンダラー。</param>
     public DesktopWindow(Renderer renderer)
     {
         this.renderer = renderer;
@@ -22,6 +30,7 @@ public class DesktopWindow : IEngineWindow
         }
     }
 
+    /// <inheritdoc />
     public void Present(ILayer layer)
     {
         renderer.Render(layer);
@@ -46,6 +55,7 @@ public class DesktopWindow : IEngineWindow
         renderer.GLView.SwapBuffers();
     }
 
+    /// <inheritdoc />
     public void Resize(SKSizeI size)
     {
         renderer.Resize(size.Width, size.Height);
@@ -56,8 +66,12 @@ public class DesktopWindow : IEngineWindow
         }
     }
 
+    /// <inheritdoc />
     public IRawPointerSource? PointerSource { get; }
 
+    /// <summary>
+    /// ポインター入力と、表示に使用した OpenGL フレームバッファを解放します。
+    /// </summary>
     public void Dispose()
     {
         PointerSource?.Dispose();

--- a/src/FloatSoda.Engine/EngineShell.cs
+++ b/src/FloatSoda.Engine/EngineShell.cs
@@ -1,10 +1,20 @@
 ﻿namespace FloatSoda.Engine;
 
+/// <summary>
+/// エンジンの開始と終了をまとめるためのシェルです。
+/// </summary>
 public class EngineShell : IDisposable
 {
+    /// <summary>
+    /// 指定したキャンセルトークンを使用してエンジンを開始します。
+    /// </summary>
+    /// <param name="token">エンジンの停止を通知するキャンセルトークン。</param>
     public void Start(CancellationToken token) {}
 
 
+    /// <summary>
+    /// エンジンシェルが保持するリソースを解放します。
+    /// </summary>
     public void Dispose()
     {
         // TODO マネージリソースをここで解放します

--- a/src/FloatSoda.Engine/FramePacer.cs
+++ b/src/FloatSoda.Engine/FramePacer.cs
@@ -3,6 +3,10 @@ using FloatSoda.Abstractions.Scheduling;
 
 namespace FloatSoda.Engine;
 
+/// <summary>
+/// スリープとスピン待機を組み合わせ、フレームループを指定した頻度に制限します。
+/// </summary>
+/// <param name="targetFrameRate">1秒あたりの目標フレーム数。既定値は60です。</param>
 public class FramePacer(int targetFrameRate = 60) : IFramePacer
 {
     private readonly Stopwatch _stopwatch = Stopwatch.StartNew();
@@ -10,6 +14,7 @@ public class FramePacer(int targetFrameRate = 60) : IFramePacer
     // 1フレームあたりの目標時間を「ティック単位」で計算
     private readonly double _targetTicksPerFrame = Stopwatch.Frequency / (double)targetFrameRate;
 
+    /// <inheritdoc />
     public void WaitForNextFrame(CancellationToken cancellationToken = default)
     {
         // 1. 前回のSyncから経過した時間を取得

--- a/src/FloatSoda.Engine/GLFWRawPointerSource.cs
+++ b/src/FloatSoda.Engine/GLFWRawPointerSource.cs
@@ -21,6 +21,11 @@ public sealed unsafe class GLFWRawPointerSource : IRawPointerSource
     /// <inheritdoc />
     public event Action<RawPointerEvent>? OnPointerEvent;
 
+    /// <summary>
+    /// 指定した GLFW ウィンドウへマウスコールバックを登録します。
+    /// </summary>
+    /// <param name="handle">入力を監視する GLFW ウィンドウのネイティブハンドル。</param>
+    /// <exception cref="ArgumentNullException"><paramref name="handle"/> が null の場合にスローされます。</exception>
     public GLFWRawPointerSource(Window* handle)
     {
         if (handle is null)
@@ -70,6 +75,9 @@ public sealed unsafe class GLFWRawPointerSource : IRawPointerSource
         _ => null,
     };
 
+    /// <summary>
+    /// GLFW ウィンドウから登録済みのマウスコールバックを解除します。
+    /// </summary>
     public void Dispose()
     {
         GLFW.SetCursorEnterCallback(_handle, null);

--- a/src/FloatSoda.Engine/GLView.cs
+++ b/src/FloatSoda.Engine/GLView.cs
@@ -4,11 +4,32 @@ using SkiaSharp;
 
 namespace FloatSoda.Engine;
 
+/// <summary>
+/// GLFW の OpenGL コンテキストと、描画先となる Skia サーフェスおよび OpenGL テクスチャを管理します。
+/// OpenGL リソースを所有するレンダースレッド上で作成、使用、破棄してください。
+/// </summary>
 public class GLView : IDisposable
 {
+    /// <summary>
+    /// OpenGL バックエンドに接続された Skia の GPU コンテキストを取得します。
+    /// </summary>
     public GRContext GrContext { get; }
+
+    /// <summary>
+    /// 現在の OpenGL テクスチャを描画先とする Skia サーフェスを取得します。
+    /// リサイズすると既存のサーフェスは破棄され、新しいインスタンスに置き換わります。
+    /// </summary>
     public SKSurface Surface { get; private set; }
+
+    /// <summary>
+    /// 描画結果を保持する OpenGL 2D テクスチャのハンドルを取得します。
+    /// リサイズすると既存のテクスチャは削除され、値が更新されます。
+    /// </summary>
     public int TextureHandle { get; private set; }
+
+    /// <summary>
+    /// 描画先のピクセルサイズを取得します。
+    /// </summary>
     public SKSizeI Size { get; private set; }
 
     /// <summary>
@@ -21,6 +42,15 @@ public class GLView : IDisposable
     private readonly unsafe Window* _window;
     private bool _disposed;
 
+    /// <summary>
+    /// GLFW ウィンドウと、その OpenGL コンテキストへ接続された Skia 描画先を作成します。
+    /// </summary>
+    /// <param name="initialSize">描画先の初期ピクセルサイズ。null の場合は1000×1000です。</param>
+    /// <param name="visible">OS 上に GLFW ウィンドウを表示する場合は <see langword="true"/>。</param>
+    /// <param name="title">可視ウィンドウのタイトル。</param>
+    /// <exception cref="InvalidOperationException">
+    /// GLFW ウィンドウ、Skia GPU コンテキスト、または Skia サーフェスを作成できない場合にスローされます。
+    /// </exception>
     public GLView(SKSizeI? initialSize = null, bool visible = false, string title = "")
     {
         Size = initialSize ?? new SKSizeI(1000, 1000);
@@ -72,6 +102,11 @@ public class GLView : IDisposable
     /// <summary>
     /// 描画先のサイズを変更します。既存のテクスチャとSurfaceは破棄され、再作成されます。
     /// </summary>
+    /// <param name="width">新しい描画先の幅（ピクセル）。</param>
+    /// <param name="height">新しい描画先の高さ（ピクセル）。</param>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="width"/> または <paramref name="height"/> が0以下の場合にスローされます。
+    /// </exception>
     public void Resize(int width, int height)
     {
         if (width <= 0 || height <= 0)
@@ -101,8 +136,18 @@ public class GLView : IDisposable
         Surface = newSurface;
     }
 
+    /// <summary>
+    /// 描画先を指定したピクセルサイズへ変更します。
+    /// </summary>
+    /// <param name="size">新しい描画先のピクセルサイズ。</param>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="size"/> の幅または高さが0以下の場合にスローされます。
+    /// </exception>
     public void Resize(SKSizeI size) => Resize(size.Width, size.Height);
 
+    /// <summary>
+    /// OpenGL コンテキストを現在のスレッドへ関連付け、描画先を透明色でクリアします。
+    /// </summary>
     public void Clear()
     {
         unsafe
@@ -115,6 +160,9 @@ public class GLView : IDisposable
         Surface.Canvas.Clear(SKColors.Transparent);
     }
 
+    /// <summary>
+    /// GLFW ウィンドウのフロントバッファとバックバッファを交換します。
+    /// </summary>
     public void SwapBuffers()
     {
         unsafe
@@ -123,6 +171,9 @@ public class GLView : IDisposable
         }
     }
 
+    /// <summary>
+    /// Skia と OpenGL に保留されている描画コマンドを送信します。
+    /// </summary>
     public void Flush()
     {
         Surface.Flush();
@@ -131,6 +182,9 @@ public class GLView : IDisposable
         GL.Flush();
     }
 
+    /// <summary>
+    /// Skia と OpenGL の描画リソースを解放し、GLFW ウィンドウを破棄します。
+    /// </summary>
     public void Dispose()
     {
         if (_disposed) return;

--- a/src/FloatSoda.Engine/OverlayMouseRawPointerSource.cs
+++ b/src/FloatSoda.Engine/OverlayMouseRawPointerSource.cs
@@ -22,6 +22,9 @@ public sealed class OverlayMouseRawPointerSource : IRawPointerSource
     /// <inheritdoc />
     public event Action<RawPointerEvent>? OnPointerEvent;
 
+    /// <summary>
+    /// 指定したイベントディスパッチャへ OpenVR のマウスイベントハンドラーを登録します。
+    /// </summary>
     /// <param name="dispatcher">対象オーバーレイのイベントディスパッチャ。</param>
     public OverlayMouseRawPointerSource(VREventDispatcher dispatcher)
     {
@@ -76,6 +79,9 @@ public sealed class OverlayMouseRawPointerSource : IRawPointerSource
         _ => null,
     };
 
+    /// <summary>
+    /// イベントディスパッチャから登録済みの OpenVR マウスイベントハンドラーを解除します。
+    /// </summary>
     public void Dispose()
     {
         _dispatcher.Unregister(EVREventType.VREvent_FocusEnter, OnFocusEnter);

--- a/src/FloatSoda.Engine/Renderer.cs
+++ b/src/FloatSoda.Engine/Renderer.cs
@@ -4,11 +4,26 @@ using SkiaSharp;
 
 namespace FloatSoda.Engine;
 
+/// <summary>
+/// レイヤーツリーを <see cref="GLView"/> の Skia サーフェスへ描画します。
+/// </summary>
 public class Renderer : IDisposable
 {
+    /// <summary>
+    /// 描画先と OpenGL リソースを所有するビューを取得します。
+    /// </summary>
     public required GLView GLView { get; init; }
+
+    /// <summary>
+    /// 描画結果を保持する OpenGL テクスチャのネイティブハンドルを取得します。
+    /// </summary>
+    /// <returns>OpenGL テクスチャ名をポインター値へ変換したハンドル。</returns>
     public IntPtr GetTextureHandle() => GLView.TextureHandle;
 
+    /// <summary>
+    /// 描画先を透明色でクリアし、指定したレイヤーツリーを描画してコマンドを送信します。
+    /// </summary>
+    /// <param name="root">描画するレイヤーツリーのルート。</param>
     public void Render(ILayer root)
     {
         var renderContext = LayerContext.Create(GLView.Surface);
@@ -21,9 +36,18 @@ public class Renderer : IDisposable
     }
 
     /// <summary>描画先の GLView を指定サイズにリサイズします。GL 呼び出しのためレンダースレッド上で呼びます。</summary>
+    /// <param name="width">新しい描画先の幅（ピクセル）。</param>
+    /// <param name="height">新しい描画先の高さ（ピクセル）。</param>
     public void Resize(int width, int height) => GLView.Resize(width, height);
 
+    /// <summary>
+    /// 描画先の GLView を指定サイズにリサイズします。GL 呼び出しのためレンダースレッド上で呼びます。
+    /// </summary>
+    /// <param name="size">新しい描画先のピクセルサイズ。</param>
     public void Resize(SKSizeI size) => GLView.Resize(size);
 
+    /// <summary>
+    /// 描画先の <see cref="GLView"/> と、その Skia および OpenGL リソースを解放します。
+    /// </summary>
     public void Dispose() => GLView.Dispose();
 }

--- a/src/FloatSoda.Engine/ThreadRunner.cs
+++ b/src/FloatSoda.Engine/ThreadRunner.cs
@@ -7,31 +7,65 @@ using OpenTK.Windowing.GraphicsLibraryFramework;
 
 namespace FloatSoda.Engine;
 
+/// <summary>
+/// 専用スレッドの開始、停止、およびタスク投入を統一する契約を定義します。
+/// </summary>
 public interface IThreadRunner
 {
+    /// <summary>
+    /// 専用スレッドを開始します。すでに実行中の場合は新しいスレッドを開始しません。
+    /// </summary>
+    /// <param name="token">専用スレッドの停止要求を通知するキャンセルトークン。</param>
     void Start(CancellationToken token);
+
+    /// <summary>
+    /// 専用スレッドへ停止を要求し、呼び出し元がそのスレッド自身でない場合は終了を待機します。
+    /// </summary>
     void Stop();
 
+    /// <summary>
+    /// 専用スレッドで実行する処理をキューへ追加します。
+    /// </summary>
+    /// <param name="action">専用スレッドで実行する処理。</param>
     void PostTask(Action action);
 
+    /// <summary>
+    /// 専用スレッドに設定される名前を取得します。
+    /// </summary>
     string ThreadName { get; }
+
+    /// <summary>
+    /// 専用スレッドが開始済みで、かつ終了していないかどうかを取得します。
+    /// </summary>
     bool IsRunning { get; }
 }
 
+/// <summary>
+/// 一定のフレーム間隔でライフサイクルフックを呼び出す専用バックグラウンドスレッドを管理します。
+/// </summary>
+/// <param name="threadName">専用スレッドに設定する名前。</param>
+/// <param name="pacer">各更新の間隔を制御するフレーム待機機構。</param>
+/// <param name="logger">専用スレッド上の失敗と停止タイムアウトを記録するロガー。記録しない場合は <see langword="null"/>。</param>
 public abstract class ThreadRunner(string threadName, IFramePacer pacer, ILogger? logger = null) : IThreadRunner
 {
     private Thread? _thread;
 
+    /// <summary>
+    /// 派生クラスが専用スレッド上の状態や失敗を記録するためのロガーを取得します。
+    /// </summary>
     protected ILogger? Logger => logger;
 
     private volatile bool _isRunning;
     private CancellationTokenSource? _linkedTokenSource;
 
+    /// <inheritdoc />
     public bool IsRunning => _isRunning && (_thread?.IsAlive ?? false);
 
 
+    /// <inheritdoc />
     public string ThreadName => threadName;
 
+    /// <inheritdoc />
     public void Start(CancellationToken ct)
     {
         lock (this)
@@ -52,6 +86,7 @@ public abstract class ThreadRunner(string threadName, IFramePacer pacer, ILogger
         }
     }
 
+    /// <inheritdoc />
     public void Stop()
     {
         Thread? targetThread;
@@ -77,6 +112,7 @@ public abstract class ThreadRunner(string threadName, IFramePacer pacer, ILogger
 
     private readonly ConcurrentQueue<Action> _pendingTasks = new();
 
+    /// <inheritdoc />
     public virtual void PostTask(Action action) => _pendingTasks.Enqueue(action);
 
     /// <summary>
@@ -130,28 +166,64 @@ public abstract class ThreadRunner(string threadName, IFramePacer pacer, ILogger
         }
     }
 
+    /// <summary>
+    /// 更新ループへ入る前に、専用スレッド上で初期化処理を実行します。
+    /// </summary>
+    /// <param name="ct">専用スレッドの停止要求を通知するキャンセルトークン。</param>
+    /// <remarks>
+    /// スレッドに所属するネイティブリソースは、このメソッドまたは以降のフックで生成してください。
+    /// </remarks>
     protected virtual void OnStart(CancellationToken ct)
     {
     }
 
+    /// <summary>
+    /// 各更新の直前に、専用スレッド上で前処理を実行します。
+    /// </summary>
     protected virtual void PreUpdate()
     {
     }
 
+    /// <summary>
+    /// 各フレームの本処理を専用スレッド上で実行します。
+    /// </summary>
     protected abstract void Update();
 
+    /// <summary>
+    /// 各更新の直後に、専用スレッド上で後処理を実行します。
+    /// </summary>
     protected virtual void PostUpdate()
     {
     }
 
+    /// <summary>
+    /// 更新ループの終了時に、専用スレッド上で終了処理を実行します。
+    /// </summary>
+    /// <remarks>
+    /// <see cref="OnStart(CancellationToken)"/> 以降に生成したスレッド所属リソースは、このメソッドで解放してください。
+    /// </remarks>
     protected virtual void OnStop()
     {
     }
 }
 
+/// <summary>
+/// GLFWイベントの処理とウィンドウへの描画を、GLFW/OpenGLコンテキストを所有するレンダースレッドで実行します。
+/// </summary>
+/// <param name="threadName">レンダースレッドに設定する名前。</param>
+/// <param name="pacer">描画ループの更新間隔を制御するフレーム待機機構。</param>
+/// <param name="logger">レンダースレッド上の失敗を記録するロガー。記録しない場合は <see langword="null"/>。</param>
 public class RenderThreadRunner(string threadName, IFramePacer pacer, ILogger? logger = null)
     : ThreadRunner(threadName, pacer, logger)
 {
+    /// <summary>
+    /// 指定したレイヤーツリーをウィンドウへ反映する処理をレンダースレッドへ追加します。
+    /// </summary>
+    /// <param name="window">レイヤーツリーの反映先となるエンジンウィンドウ。</param>
+    /// <param name="layer">反映するレイヤーツリー。</param>
+    /// <remarks>
+    /// 呼び出し元はレンダースレッドである必要はありません。実際の描画はレンダースレッド上で行われます。
+    /// </remarks>
     public void PostRender(IEngineWindow window, ILayer layer)
     {
         PostTask(() =>
@@ -162,15 +234,31 @@ public class RenderThreadRunner(string threadName, IFramePacer pacer, ILogger? l
         });
     }
 
+    /// <summary>
+    /// レンダースレッドへ投入された描画処理とその他のタスクを、GLFWイベント処理の前に実行します。
+    /// </summary>
     protected override void PreUpdate() => DrainPendingTasks();
 
+    /// <summary>
+    /// レンダースレッド上でGLFWを初期化し、ウィンドウとOpenGLリソースを生成できる状態にします。
+    /// </summary>
+    /// <param name="ct">初期化前の停止要求を通知するキャンセルトークン。</param>
     protected override void OnStart(CancellationToken ct)
     {
         ct.ThrowIfCancellationRequested();
         if (!GLFW.Init()) throw new Exception("GLFWの初期化に失敗しました。");
     }
 
+    /// <summary>
+    /// レンダースレッド上でGLFWイベントを処理します。
+    /// </summary>
     protected override void Update() => GLFW.PollEvents();
 
+    /// <summary>
+    /// レンダースレッド上でGLFWを終了します。
+    /// </summary>
+    /// <remarks>
+    /// GLFWウィンドウとOpenGLリソースは、このメソッドが呼ばれる前に同じレンダースレッド上で解放されている必要があります。
+    /// </remarks>
     protected override void OnStop() => GLFW.Terminate();
 }

--- a/src/FloatSoda.Rendering/LayerBitmapRenderer.cs
+++ b/src/FloatSoda.Rendering/LayerBitmapRenderer.cs
@@ -8,6 +8,29 @@ namespace FloatSoda.Rendering;
 /// </summary>
 public sealed class LayerBitmapRenderer
 {
+    /// <summary>
+    /// レイヤーツリーをレイアウトし、透明で初期化した新しいビットマップへ描画します。
+    /// </summary>
+    /// <param name="root">
+    /// 描画するレイヤーツリーのルート。<see langword="null"/>は指定できません。
+    /// 所有権は呼び出し元に残ります。
+    /// </param>
+    /// <param name="imageSize">
+    /// 出力するビットマップのピクセル単位の大きさ。幅と高さには正の値を指定します。
+    /// </param>
+    /// <returns>
+    /// 描画結果を保持する新しいビットマップ。呼び出し元が破棄する必要があります。
+    /// </returns>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="root"/>が<see langword="null"/>の場合にスローされます。
+    /// </exception>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="imageSize"/>の幅または高さが0以下の場合にスローされます。
+    /// </exception>
+    /// <remarks>
+    /// レイアウトにより、ツリー内の各レイヤーの描画境界が更新されます。
+    /// </remarks>
+    /// <seealso cref="LayerRenderer"/>
     public SKBitmap Render(ILayer root, SKSizeI imageSize)
     {
         ArgumentNullException.ThrowIfNull(root);

--- a/src/FloatSoda.Rendering/LayerRenderer.cs
+++ b/src/FloatSoda.Rendering/LayerRenderer.cs
@@ -8,6 +8,24 @@ namespace FloatSoda.Rendering;
 /// </summary>
 public static class LayerRenderer
 {
+    /// <summary>
+    /// レイヤーツリーのレイアウトを完了してから、指定された描画先へツリーを合成します。
+    /// </summary>
+    /// <param name="root">
+    /// 描画するレイヤーツリーのルート。<see langword="null"/>は指定できません。
+    /// 所有権は呼び出し元に残ります。
+    /// </param>
+    /// <param name="context">
+    /// 描画先のキャンバスを保持するコンテキスト。キャンバスの所有権は呼び出し元に残ります。
+    /// </param>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="root"/>が<see langword="null"/>の場合にスローされます。
+    /// </exception>
+    /// <remarks>
+    /// 描画先のクリア、フラッシュ、および破棄は行いません。
+    /// レイアウトにより、ツリー内の各レイヤーの描画境界が更新されます。
+    /// </remarks>
+    /// <seealso cref="LayerBitmapRenderer"/>
     public static void Render(ILayer root, LayerContext context)
     {
         ArgumentNullException.ThrowIfNull(root);

--- a/src/FloatSoda.Rendering/Layers/ClipRectLayer.cs
+++ b/src/FloatSoda.Rendering/Layers/ClipRectLayer.cs
@@ -2,12 +2,35 @@
 
 namespace FloatSoda.Rendering.Layers;
 
+/// <summary>
+/// すべての子レイヤーの描画を矩形の内側へ制限するレイヤーです。
+/// </summary>
+/// <param name="clipRect">
+/// 子レイヤーの描画を許可する矩形。
+/// </param>
+/// <seealso cref="ClipRoundRectLayer"/>
+/// <seealso cref="ClipPathLayer"/>
 public class ClipRectLayer(SKRect clipRect) : ContainerLayer
 {
+    /// <summary>
+    /// 子レイヤーの描画を許可する矩形を取得または設定します。
+    /// </summary>
     public SKRect ClipRect { get; set; } = clipRect;
+    /// <summary>
+    /// クリップ境界の描画品質を取得または設定します。
+    /// </summary>
+    /// <value>
+    /// 境界に適用するクリップ方式。既定値は<see cref="Clip.Antialias"/>です。
+    /// </value>
     public Clip ClipBehavior { get; set; } = Clip.Antialias;
 
 
+    /// <summary>
+    /// 子レイヤーをレイアウトし、クリップ矩形と重なる描画領域を評価します。
+    /// </summary>
+    /// <param name="context">
+    /// 子レイヤーのレイアウトに使用するコンテキスト。
+    /// </param>
     public override void Layout(LayerContext context)
     {
         var clipPathBounds = LayoutChildren(context);
@@ -20,6 +43,15 @@ public class ClipRectLayer(SKRect clipRect) : ContainerLayer
         context.Canvas.Restore();
     }
 
+    /// <summary>
+    /// クリップ矩形の内側に限って子レイヤーを描画します。
+    /// </summary>
+    /// <param name="context">
+    /// クリップした子レイヤーを合成するキャンバスを保持するコンテキスト。
+    /// </param>
+    /// <remarks>
+    /// 描画後にキャンバスの状態を復元するため、後続のレイヤーへクリップは引き継がれません。
+    /// </remarks>
     public override void Paint(LayerContext context)
     {
         context.Canvas.Save();
@@ -29,6 +61,12 @@ public class ClipRectLayer(SKRect clipRect) : ContainerLayer
         context.Canvas.Restore();
     }
 
+    /// <summary>
+    /// クリップ矩形、クリップ方式、および子レイヤーを保持する新しいレイヤーを作成します。
+    /// </summary>
+    /// <returns>
+    /// 子レイヤーを再帰的に複製した新しい矩形クリップレイヤー。
+    /// </returns>
     public override ILayer Clone()
     {
         var cloned = new ClipRectLayer(ClipRect)
@@ -45,12 +83,38 @@ public class ClipRectLayer(SKRect clipRect) : ContainerLayer
     }
 }
 
+/// <summary>
+/// すべての子レイヤーの描画を角丸矩形の内側へ制限するレイヤーです。
+/// </summary>
+/// <param name="clipRect">
+/// 子レイヤーの描画を許可する角丸矩形。所有権は呼び出し元に残ります。
+/// </param>
+/// <seealso cref="ClipRectLayer"/>
+/// <seealso cref="ClipPathLayer"/>
 public class ClipRoundRectLayer(SKRoundRect clipRect) : ContainerLayer
 {
+    /// <summary>
+    /// 子レイヤーの描画を許可する角丸矩形を取得または設定します。
+    /// </summary>
+    /// <value>
+    /// クリップに使用する角丸矩形。所有権は呼び出し元に残ります。
+    /// </value>
     public SKRoundRect ClipRect { get; set; } = clipRect;
+    /// <summary>
+    /// クリップ境界の描画品質を取得または設定します。
+    /// </summary>
+    /// <value>
+    /// 境界に適用するクリップ方式。既定値は<see cref="Clip.Antialias"/>です。
+    /// </value>
     public Clip ClipBehavior { get; set; } = Clip.Antialias;
 
 
+    /// <summary>
+    /// 子レイヤーをレイアウトし、角丸矩形の外接矩形と重なる描画領域を評価します。
+    /// </summary>
+    /// <param name="context">
+    /// 子レイヤーのレイアウトに使用するコンテキスト。
+    /// </param>
     public override void Layout(LayerContext context)
     {
         var clipPathBounds = LayoutChildren(context);
@@ -63,6 +127,15 @@ public class ClipRoundRectLayer(SKRoundRect clipRect) : ContainerLayer
         context.Canvas.Restore();
     }
 
+    /// <summary>
+    /// 角丸矩形の内側に限って子レイヤーを描画します。
+    /// </summary>
+    /// <param name="context">
+    /// クリップした子レイヤーを合成するキャンバスを保持するコンテキスト。
+    /// </param>
+    /// <remarks>
+    /// 描画後にキャンバスの状態を復元するため、後続のレイヤーへクリップは引き継がれません。
+    /// </remarks>
     public override void Paint(LayerContext context)
     {
         context.Canvas.Save();
@@ -72,6 +145,12 @@ public class ClipRoundRectLayer(SKRoundRect clipRect) : ContainerLayer
         context.Canvas.Restore();
     }
 
+    /// <summary>
+    /// 角丸矩形、クリップ方式、および子レイヤーを保持する新しいレイヤーを作成します。
+    /// </summary>
+    /// <returns>
+    /// 子レイヤーを再帰的に複製した新しい角丸矩形クリップレイヤー。
+    /// </returns>
     public override ILayer Clone()
     {
         var cloned = new ClipRoundRectLayer(ClipRect)
@@ -88,11 +167,37 @@ public class ClipRoundRectLayer(SKRoundRect clipRect) : ContainerLayer
     }
 }
 
+/// <summary>
+/// すべての子レイヤーの描画をパスの内側へ制限するレイヤーです。
+/// </summary>
+/// <param name="clipPath">
+/// 子レイヤーの描画を許可するパス。所有権は呼び出し元に残ります。
+/// </param>
+/// <seealso cref="ClipRectLayer"/>
+/// <seealso cref="ClipRoundRectLayer"/>
 public class ClipPathLayer(SKPath clipPath) : ContainerLayer
 {
+    /// <summary>
+    /// 子レイヤーの描画を許可するパスを取得または設定します。
+    /// </summary>
+    /// <value>
+    /// クリップに使用するパス。所有権は呼び出し元に残り、使用中は有効な状態に保つ必要があります。
+    /// </value>
     public SKPath ClipPath { get; set; } = clipPath;
+    /// <summary>
+    /// クリップ境界の描画品質を取得または設定します。
+    /// </summary>
+    /// <value>
+    /// 境界に適用するクリップ方式。既定値は<see cref="Clip.Antialias"/>です。
+    /// </value>
     public Clip ClipBehavior { get; set; } = Clip.Antialias;
 
+    /// <summary>
+    /// 子レイヤーをレイアウトし、クリップパスの境界と重なる描画領域を評価します。
+    /// </summary>
+    /// <param name="context">
+    /// 子レイヤーのレイアウトに使用するコンテキスト。
+    /// </param>
     public override void Layout(LayerContext context)
     {
         var clipPathBounds = ClipPath.Bounds;
@@ -104,6 +209,15 @@ public class ClipPathLayer(SKPath clipPath) : ContainerLayer
         }
     }
 
+    /// <summary>
+    /// クリップパスの内側に限って子レイヤーを描画します。
+    /// </summary>
+    /// <param name="context">
+    /// クリップした子レイヤーを合成するキャンバスを保持するコンテキスト。
+    /// </param>
+    /// <remarks>
+    /// 描画後にキャンバスの状態を復元するため、後続のレイヤーへクリップは引き継がれません。
+    /// </remarks>
     public override void Paint(LayerContext context)
     {
         context.Canvas.Save();
@@ -112,6 +226,15 @@ public class ClipPathLayer(SKPath clipPath) : ContainerLayer
         context.Canvas.Restore();
     }
 
+    /// <summary>
+    /// クリップパス、クリップ方式、および子レイヤーを保持する新しいレイヤーを作成します。
+    /// </summary>
+    /// <returns>
+    /// 子レイヤーを再帰的に複製した新しいパスクリップレイヤー。
+    /// </returns>
+    /// <remarks>
+    /// クリップパスの所有権は移転せず、複製元と同じパスを参照します。
+    /// </remarks>
     public override ILayer Clone()
     {
         var cloned = new ClipPathLayer(ClipPath) { ClipBehavior = ClipBehavior };
@@ -125,9 +248,21 @@ public class ClipPathLayer(SKPath clipPath) : ContainerLayer
     }
 }
 
+/// <summary>
+/// クリップ境界の描画方式を指定します。
+/// </summary>
 public enum Clip
 {
+    /// <summary>
+    /// 境界へアンチエイリアスを適用しません。
+    /// </summary>
     None,
+    /// <summary>
+    /// 境界をアンチエイリアスなしの明瞭な輪郭で描画します。
+    /// </summary>
     HardEdge,
+    /// <summary>
+    /// 境界へアンチエイリアスを適用して描画します。
+    /// </summary>
     Antialias
 }

--- a/src/FloatSoda.Rendering/Layers/ContainerLayer.cs
+++ b/src/FloatSoda.Rendering/Layers/ContainerLayer.cs
@@ -2,16 +2,53 @@
 
 namespace FloatSoda.Rendering.Layers;
 
+/// <summary>
+/// 子レイヤーを保持し、一覧の順序で同じ描画先へ合成するレイヤーです。
+/// </summary>
+/// <seealso cref="PictureLayer"/>
 public class ContainerLayer : ILayer
 {
+    /// <summary>
+    /// 合成する子レイヤーの一覧を取得します。
+    /// </summary>
+    /// <value>
+    /// 前の要素から順に描画される、変更可能な子レイヤーの一覧。
+    /// </value>
     public List<ILayer> Children { get; } = [];
 
+    /// <summary>
+    /// 子レイヤーが1つ以上存在するかどうかを取得します。
+    /// </summary>
+    /// <value>
+    /// 子レイヤーが存在する場合は<see langword="true"/>、存在しない場合は<see langword="false"/>。
+    /// </value>
     public bool HasChildren => Children.Count != 0;
 
+    /// <summary>
+    /// レイアウト後のすべての子レイヤーを包含する描画境界を取得します。
+    /// </summary>
+    /// <value>
+    /// 親レイヤーの座標系で表した子レイヤーの描画境界の和集合。
+    /// </value>
     public SKRect PaintBounds { get; protected set; }
 
+    /// <summary>
+    /// すべての子レイヤーをレイアウトし、それらを包含する描画境界を設定します。
+    /// </summary>
+    /// <param name="context">
+    /// 子レイヤーのレイアウトに使用するコンテキスト。
+    /// </param>
     public virtual void Layout(LayerContext context) => PaintBounds = LayoutChildren(context);
 
+    /// <summary>
+    /// すべての子レイヤーをレイアウトし、それらを包含する描画境界を返します。
+    /// </summary>
+    /// <param name="context">
+    /// 子レイヤーのレイアウトに使用するコンテキスト。
+    /// </param>
+    /// <returns>
+    /// 子レイヤーが描画へ影響する境界の和集合。子が存在しない場合は空の矩形。
+    /// </returns>
     protected SKRect LayoutChildren(LayerContext context)
     {
         var bounds = SKRect.Empty;
@@ -25,6 +62,12 @@ public class ContainerLayer : ILayer
         return bounds;
     }
 
+    /// <summary>
+    /// 子レイヤーを一覧の先頭から順に描画します。
+    /// </summary>
+    /// <param name="context">
+    /// 子レイヤーの合成先となるキャンバスを保持するコンテキスト。
+    /// </param>
     public virtual void Paint(LayerContext context)
     {
         foreach (var child in Children)
@@ -33,6 +76,12 @@ public class ContainerLayer : ILayer
         }
     }
 
+    /// <summary>
+    /// すべての子レイヤーを再帰的に複製した、新しいコンテナーレイヤーを作成します。
+    /// </summary>
+    /// <returns>
+    /// 子レイヤーの一覧を独立して保持する新しいコンテナーレイヤー。
+    /// </returns>
     public virtual ILayer Clone()
     {
         var cloned = new ContainerLayer();

--- a/src/FloatSoda.Rendering/Layers/ILayer.cs
+++ b/src/FloatSoda.Rendering/Layers/ILayer.cs
@@ -2,11 +2,44 @@
 
 namespace FloatSoda.Rendering.Layers;
 
+/// <summary>
+/// 描画内容と合成処理から成るレイヤーツリーの要素を表します。
+/// </summary>
+/// <remarks>
+/// レイアウトで描画境界を確定した後、同じコンテキストを使用して描画します。
+/// </remarks>
 public interface ILayer
 {
+    /// <summary>
+    /// レイアウト後にこのレイヤーが描画へ影響する境界を取得します。
+    /// </summary>
+    /// <value>
+    /// 親レイヤーの座標系で表した描画境界。
+    /// </value>
     public SKRect PaintBounds { get; }
 
+    /// <summary>
+    /// このレイヤーと子レイヤーの描画境界を計算します。
+    /// </summary>
+    /// <param name="context">
+    /// 描画先の座標系とキャンバスを保持するコンテキスト。
+    /// </param>
     void Layout(LayerContext context);
+    /// <summary>
+    /// レイアウト済みの内容を指定された描画先へ合成します。
+    /// </summary>
+    /// <param name="context">
+    /// 合成先のキャンバスを保持するコンテキスト。
+    /// </param>
     void Paint(LayerContext context);
+    /// <summary>
+    /// 現在の合成設定を保持する、独立したレイヤーツリーを作成します。
+    /// </summary>
+    /// <returns>
+    /// 子レイヤーを含めて複製された新しいレイヤー。
+    /// </returns>
+    /// <remarks>
+    /// 描画リソースの所有権は移転せず、複製元と共有される場合があります。
+    /// </remarks>
     ILayer Clone();
 }

--- a/src/FloatSoda.Rendering/Layers/LayerContext.cs
+++ b/src/FloatSoda.Rendering/Layers/LayerContext.cs
@@ -2,7 +2,22 @@
 
 namespace FloatSoda.Rendering.Layers;
 
+/// <summary>
+/// レイヤーツリーのレイアウトと描画で共有する描画先を表します。
+/// </summary>
+/// <param name="Canvas">
+/// レイヤーの描画先となるキャンバス。所有権は呼び出し元に残ります。
+/// </param>
 public readonly record struct LayerContext(SKCanvas Canvas)
 {
+    /// <summary>
+    /// サーフェスのキャンバスを描画先とするコンテキストを作成します。
+    /// </summary>
+    /// <param name="surface">
+    /// 描画先のサーフェス。所有権は呼び出し元に残り、コンテキストの使用中は有効な状態に保つ必要があります。
+    /// </param>
+    /// <returns>
+    /// 指定されたサーフェスのキャンバスを参照するコンテキスト。
+    /// </returns>
     public static LayerContext Create(SKSurface surface) => new(surface.Canvas);
 }

--- a/src/FloatSoda.Rendering/Layers/OpacityLayer.cs
+++ b/src/FloatSoda.Rendering/Layers/OpacityLayer.cs
@@ -2,10 +2,28 @@
 
 namespace FloatSoda.Rendering.Layers;
 
+/// <summary>
+/// すべての子レイヤーをひとまとまりとして、指定された不透明度で合成するレイヤーです。
+/// </summary>
 public class OpacityLayer : ContainerLayer
 {
+    /// <summary>
+    /// 子レイヤーの合成に適用する不透明度を取得または設定します。
+    /// </summary>
+    /// <value>
+    /// 0を完全な透明、255を完全な不透明とする値。既定値は255です。
+    /// </value>
     public byte Alpha { get; set; } = 255;
 
+    /// <summary>
+    /// 子レイヤーを一時レイヤーへ描画し、指定された不透明度で描画先へ合成します。
+    /// </summary>
+    /// <param name="context">
+    /// 子レイヤーの合成先となるキャンバスを保持するコンテキスト。
+    /// </param>
+    /// <remarks>
+    /// 合成後にキャンバスの状態を復元するため、後続のレイヤーへ不透明度は引き継がれません。
+    /// </remarks>
     public override void Paint(LayerContext context)
     {
         var paint = new SKPaint()
@@ -21,6 +39,12 @@ public class OpacityLayer : ContainerLayer
         context.Canvas.Restore();
     }
 
+    /// <summary>
+    /// 不透明度と子レイヤーを保持する新しい不透明度レイヤーを作成します。
+    /// </summary>
+    /// <returns>
+    /// 子レイヤーを再帰的に複製した新しい不透明度レイヤー。
+    /// </returns>
     public override ILayer Clone()
     {
         var cloned = new OpacityLayer { Alpha = Alpha };

--- a/src/FloatSoda.Rendering/Layers/PictureLayer.cs
+++ b/src/FloatSoda.Rendering/Layers/PictureLayer.cs
@@ -2,23 +2,61 @@
 
 namespace FloatSoda.Rendering.Layers;
 
+/// <summary>
+/// 記録済みの描画命令を再生するレイヤーです。
+/// </summary>
+/// <seealso cref="ContainerLayer"/>
 public class PictureLayer : ILayer
 {
+    /// <summary>
+    /// 再生する記録済みの描画命令を取得または設定します。
+    /// </summary>
+    /// <value>
+    /// 描画するピクチャー。<see langword="null"/>の場合は何も描画しません。
+    /// 所有権はこのレイヤーへ移転せず、使用中は呼び出し元が有効な状態に保つ必要があります。
+    /// </value>
     public SKPicture? Picture { get; set; }
 
+    /// <summary>
+    /// レイアウト後のピクチャーの描画境界を取得します。
+    /// </summary>
+    /// <value>
+    /// ピクチャーに記録された描画境界。ピクチャーが<see langword="null"/>の場合は空の矩形。
+    /// </value>
     public SKRect PaintBounds { get; private set; }
 
 
+    /// <summary>
+    /// ピクチャーに記録された描画境界をこのレイヤーの描画境界として設定します。
+    /// </summary>
+    /// <param name="context">
+    /// レイヤーツリーのレイアウトに使用するコンテキスト。
+    /// </param>
     public void Layout(LayerContext context)
     {
         PaintBounds = Picture?.CullRect ?? new SKRect();
     }
 
+    /// <summary>
+    /// 記録済みの描画命令を指定されたキャンバスへ再生します。
+    /// </summary>
+    /// <param name="context">
+    /// 描画命令の再生先となるキャンバスを保持するコンテキスト。
+    /// </param>
     public void Paint(LayerContext context)
     {
         Picture?.Playback(context.Canvas);
     }
 
+    /// <summary>
+    /// 同じピクチャーを参照する新しいピクチャーレイヤーを作成します。
+    /// </summary>
+    /// <returns>
+    /// ピクチャーへの参照を共有する新しいピクチャーレイヤー。
+    /// </returns>
+    /// <remarks>
+    /// ピクチャーの所有権は移転しません。描画境界は複製後のレイアウトで計算されます。
+    /// </remarks>
     public ILayer Clone() => new PictureLayer()
     {
         Picture = Picture

--- a/src/FloatSoda.Rendering/Layers/TransformLayer.cs
+++ b/src/FloatSoda.Rendering/Layers/TransformLayer.cs
@@ -2,10 +2,25 @@
 
 namespace FloatSoda.Rendering.Layers;
 
+/// <summary>
+/// すべての子レイヤーへ同じ座標変換を適用して合成するレイヤーです。
+/// </summary>
 public class TransformLayer : ContainerLayer
 {
+    /// <summary>
+    /// 子レイヤーの座標系へ適用する変換行列を取得または設定します。
+    /// </summary>
+    /// <value>
+    /// レイアウト境界と描画内容の両方へ適用する変換行列。既定値は恒等変換です。
+    /// </value>
     public SKMatrix Transform { get; set; } = SKMatrix.Identity;
 
+    /// <summary>
+    /// 子レイヤーをレイアウトし、変換後の領域をこのレイヤーの描画境界として設定します。
+    /// </summary>
+    /// <param name="context">
+    /// 子レイヤーのレイアウトに使用するコンテキスト。
+    /// </param>
     public override void Layout(LayerContext context)
     {
         var childBounds = LayoutChildren(context);
@@ -13,6 +28,15 @@ public class TransformLayer : ContainerLayer
         PaintBounds = Transform.MapRect(childBounds);
     }
 
+    /// <summary>
+    /// 変換行列を子レイヤーの座標系へ適用して描画します。
+    /// </summary>
+    /// <param name="context">
+    /// 変換後の子レイヤーを合成するキャンバスを保持するコンテキスト。
+    /// </param>
+    /// <remarks>
+    /// 描画後にキャンバスの状態を復元するため、後続のレイヤーへ変換は引き継がれません。
+    /// </remarks>
     public override void Paint(LayerContext context)
     {
         context.Canvas.Save();
@@ -23,6 +47,12 @@ public class TransformLayer : ContainerLayer
         context.Canvas.Restore();
     }
 
+    /// <summary>
+    /// 変換行列と子レイヤーを保持する新しい変換レイヤーを作成します。
+    /// </summary>
+    /// <returns>
+    /// 子レイヤーを再帰的に複製した新しい変換レイヤー。
+    /// </returns>
     public override ILayer Clone()
     {
         var cloned = new TransformLayer()

--- a/src/FloatSoda.Rendering/SKBitmapExtensions.cs
+++ b/src/FloatSoda.Rendering/SKBitmapExtensions.cs
@@ -2,8 +2,30 @@ using SkiaSharp;
 
 namespace FloatSoda.Rendering;
 
+/// <summary>
+/// ビットマップの保存操作を提供します。
+/// </summary>
 public static class SKBitmapExtensions
 {
+    /// <summary>
+    /// ビットマップを指定された形式で符号化し、ファイルへ保存します。
+    /// </summary>
+    /// <param name="bitmap">
+    /// 保存するビットマップ。所有権は呼び出し元に残ります。
+    /// </param>
+    /// <param name="path">
+    /// 保存先のファイルパス。既存のファイルは上書きされます。
+    /// </param>
+    /// <param name="format">
+    /// 出力する画像形式。既定値は<see cref="SKEncodedImageFormat.Png"/>です。
+    /// </param>
+    /// <param name="quality">
+    /// 符号化品質を表す0から100までの値。既定値は100で、解釈は画像形式に依存します。
+    /// </param>
+    /// <remarks>
+    /// 相対パスは現在の作業ディレクトリを基準に解決されます。
+    /// 保存先の親ディレクトリは作成しません。
+    /// </remarks>
     public static void Save(
         this SKBitmap bitmap,
         string path,

--- a/src/FloatSoda/Elements/BuildContext.cs
+++ b/src/FloatSoda/Elements/BuildContext.cs
@@ -2,11 +2,44 @@
 
 namespace FloatSoda.Elements;
 
+/// <summary>
+/// Widgetの構築時に、現在の構成と祖先から伝播した情報へアクセスするためのコンテキストです。
+/// </summary>
+/// <seealso cref="Element"/>
 public interface IBuildContext
 {
+    /// <summary>
+    /// このコンテキストに対応する現在のWidgetを取得します。
+    /// </summary>
     Widget Widget { get; }
+    /// <summary>
+    /// このコンテキストが属するElementツリーのビルド管理者を取得します。
+    /// ツリーへ接続されていない場合は<see langword="null"/>です。
+    /// </summary>
     BuildOwner? Owner { get; }
+    /// <summary>
+    /// 指定した型として登録された最も近い祖先のInheritedWidgetを取得し、
+    /// このコンテキストとの依存関係を登録します。
+    /// </summary>
+    /// <typeparam name="T">検索するInheritedWidgetの型。</typeparam>
+    /// <returns>
+    /// 該当する祖先のInheritedWidget。該当する祖先が存在しない場合は<see langword="null"/>。
+    /// </returns>
+    /// <remarks>
+    /// 取得したInheritedWidgetが更新を通知すると、このコンテキストに対応するElementは再構築を要求されます。
+    /// </remarks>
+    /// <seealso cref="InheritedElement"/>
     T? DependOnInheritedWidgetOfExactType<T>() where T : InheritedWidget;
 
+    /// <summary>
+    /// 指定した型として登録された最も近い祖先のInheritedWidgetに対応するElementを取得します。
+    /// </summary>
+    /// <typeparam name="T">検索するInheritedWidgetの型。</typeparam>
+    /// <returns>
+    /// 該当する祖先の<see cref="InheritedElement"/>。
+    /// 該当する祖先が存在しない場合は<see langword="null"/>。
+    /// </returns>
+    /// <remarks>このメソッドは取得したElementへの依存関係を登録しません。</remarks>
+    /// <seealso cref="InheritedWidget"/>
     InheritedElement? GetElementForInheritedWidgetOfExactType<T>() where T : InheritedWidget;
 }

--- a/src/FloatSoda/Elements/BuildOwner.cs
+++ b/src/FloatSoda/Elements/BuildOwner.cs
@@ -3,6 +3,12 @@ using FloatSoda.Gesture;
 
 namespace FloatSoda.Elements;
 
+/// <summary>
+/// 1つのElementツリーについて、再構築が必要なElementの予約と実行順序を管理します。
+/// </summary>
+/// <param name="onBuildScheduled">
+/// 再構築待ちリストが空の状態から最初のElementが予約されたときに呼び出す処理。
+/// </param>
 public class BuildOwner(Action onBuildScheduled)
 {
     /// <summary>
@@ -21,6 +27,14 @@ public class BuildOwner(Action onBuildScheduled)
     private bool? _dirtyElementsNeedsRestoring;
     private bool _scheduledFlushDirtyElements;
 
+    /// <summary>
+    /// 指定したElementを次のビルドスコープで再構築する対象として登録します。
+    /// </summary>
+    /// <param name="element">再構築が必要なElement。</param>
+    /// <remarks>
+    /// Elementがまだ待ちリストにない場合だけ追加します。
+    /// 最初のElementを追加すると、コンストラクターで指定されたビルド予約処理を呼び出します。
+    /// </remarks>
     public void ScheduledBuildFor(Element element)
     {
         if (element.InDirtyList)
@@ -38,6 +52,16 @@ public class BuildOwner(Action onBuildScheduled)
         element.InDirtyList = true;
     }
 
+    /// <summary>
+    /// 任意の処理を実行した後、予約されたElementを親に近い順で再構築します。
+    /// </summary>
+    /// <param name="callback">
+    /// 再構築待ちリストを処理する前に実行する処理。追加処理が不要な場合は<see langword="null"/>。
+    /// </param>
+    /// <remarks>
+    /// 処理中に新たな再構築が予約された場合も順序を再評価して同じスコープ内で処理します。
+    /// 完了後は、処理したElementの待ちリスト登録状態を解除します。
+    /// </remarks>
     public void BuildScope(Action? callback = null)
     {
         if (callback == null && _dirtyElements.Count == 0) return;

--- a/src/FloatSoda/Elements/ComponentElement.cs
+++ b/src/FloatSoda/Elements/ComponentElement.cs
@@ -2,19 +2,32 @@ using FloatSoda.Widgets;
 
 namespace FloatSoda.Elements;
 
+/// <summary>
+/// Widgetの構築結果として得られる単一の子Widgetを管理するElementの基底クラスです。
+/// </summary>
 public abstract class ComponentElement : Element
 {
     private Element? Child { get; set; }
 
+    /// <summary>
+    /// Elementツリーへ接続し、最初の構築を直ちに実行します。
+    /// </summary>
+    /// <param name="parent">接続先の親Element。ルートとして接続する場合は<see langword="null"/>。</param>
     public override void Mount(Element? parent)
     {
         base.Mount(parent);
         FirstBuild();
     }
 
+    /// <summary>
+    /// このElementの初回構築を実行します。
+    /// </summary>
     public virtual void FirstBuild() => Rebuild();
 
 
+    /// <summary>
+    /// 現在のWidgetから子Widgetを構築し、既存の子Elementを再利用できる場合は更新して置き換えます。
+    /// </summary>
     public override void PerformRebuild()
     {
         var built = Build();
@@ -22,18 +35,35 @@ public abstract class ComponentElement : Element
         Child = UpdateChild(Child, built);
     }
 
+    /// <summary>
+    /// このElementが管理するWidgetから、子として構成するWidgetを生成します。
+    /// </summary>
+    /// <returns>このElementの直下に配置するWidget。</returns>
     public abstract Widget Build();
 
+    /// <inheritdoc/>
     public override void VisitChildren(Action<Element> visitor)
     {
         if (Child != null) visitor(Child);
     }
 }
 
+/// <summary>
+/// StatelessWidgetの構築結果を単一の子Elementとして管理するElementです。
+/// </summary>
+/// <seealso cref="StatelessWidget"/>
 public class StatelessElement : ComponentElement
 {
+    /// <summary>
+    /// 管理しているStatelessWidgetから子Widgetを構築します。
+    /// </summary>
+    /// <returns>StatelessWidgetが構築した子Widget。</returns>
     public override Widget Build() => ((StatelessWidget)Widget!).Build(this);
 
+    /// <summary>
+    /// 管理するStatelessWidgetを置き換え、新しい構成で直ちに再構築します。
+    /// </summary>
+    /// <param name="newWidget">このElementを引き継ぐ新しいStatelessWidget。</param>
     public override void Update(Widget newWidget)
     {
         base.Update(newWidget);
@@ -42,8 +72,18 @@ public class StatelessElement : ComponentElement
     }
 }
 
+/// <summary>
+/// StatefulWidgetと、そのライフサイクルを担うStateを結び付けて管理するElementです。
+/// </summary>
+/// <typeparam name="T">このElementが管理するStatefulWidgetの型。</typeparam>
+/// <seealso cref="StatefulWidget{T}"/>
+/// <seealso cref="State{T}"/>
 public class StatefulElement<T> : ComponentElement where T : StatefulWidget<T>
 {
+    /// <summary>
+    /// このElementが所有するStateを取得します。
+    /// </summary>
+    /// <remarks>Stateはマウント時に生成され、Elementがツリーから恒久的に外れるまで保持されます。</remarks>
     public State<T> State => _stateInternal!;
     private State<T>? _stateInternal = null;
     private bool _didChangeDependencies = false;
@@ -51,6 +91,10 @@ public class StatefulElement<T> : ComponentElement where T : StatefulWidget<T>
     /// <summary><see cref="State{T}.Dispose"/>をすでに呼び出したかどうか。</summary>
     private bool _stateDisposed = false;
 
+    /// <summary>
+    /// WidgetからStateを生成して相互に関連付けた後、Elementツリーへ接続します。
+    /// </summary>
+    /// <param name="parent">接続先の親Element。ルートとして接続する場合は<see langword="null"/>。</param>
     public override void Mount(Element? parent)
     {
         _stateInternal = ((StatefulWidget<T>)Widget!).CreateState();
@@ -59,6 +103,9 @@ public class StatefulElement<T> : ComponentElement where T : StatefulWidget<T>
         base.Mount(parent);
     }
 
+    /// <summary>
+    /// Stateの初期化と初回の依存変更通知を行った後、最初のWidget構築を実行します。
+    /// </summary>
     public override void FirstBuild()
     {
         State.InitState();
@@ -66,6 +113,9 @@ public class StatefulElement<T> : ComponentElement where T : StatefulWidget<T>
         base.FirstBuild();
     }
 
+    /// <summary>
+    /// 保留中の依存変更をStateへ通知した後、Stateから子Widgetを再構築します。
+    /// </summary>
     public override void PerformRebuild()
     {
         if (_didChangeDependencies)
@@ -78,8 +128,16 @@ public class StatefulElement<T> : ComponentElement where T : StatefulWidget<T>
     }
 
 
+    /// <summary>
+    /// 所有するStateから子Widgetを構築します。
+    /// </summary>
+    /// <returns>Stateが構築した子Widget。</returns>
     public override Widget Build() => State.Build(this);
 
+    /// <summary>
+    /// 管理するStatefulWidgetを置き換え、Stateへ更新前のWidgetを通知して直ちに再構築します。
+    /// </summary>
+    /// <param name="newWidget">既存のStateを引き継ぐ新しいStatefulWidget。</param>
     public override void Update(Widget newWidget)
     {
         base.Update(newWidget);
@@ -91,6 +149,9 @@ public class StatefulElement<T> : ComponentElement where T : StatefulWidget<T>
         Rebuild();
     }
 
+    /// <summary>
+    /// 依存するInheritedWidgetの変更を次の再構築時にStateへ通知するよう予約します。
+    /// </summary>
     public override void DidChangeDependencies()
     {
         base.DidChangeDependencies();

--- a/src/FloatSoda/Elements/Element.cs
+++ b/src/FloatSoda/Elements/Element.cs
@@ -3,14 +3,36 @@ using FloatSoda.Widgets;
 
 namespace FloatSoda.Elements;
 
+/// <summary>
+/// Widgetツリー上の位置と可変状態を保持し、Widgetの更新をRenderObjectツリーへ反映する要素の基底クラスです。
+/// </summary>
+/// <seealso cref="Widget"/>
+/// <seealso cref="RenderObject"/>
 public abstract class Element : IBuildContext, IComparable<Element>
 {
+    /// <summary>
+    /// このElementが現在管理しているWidgetを取得または設定します。
+    /// ElementへWidgetが割り当てられる前は<see langword="null"/>です。
+    /// </summary>
     public Widget? Widget { get; set; }
 
+    /// <summary>
+    /// Elementツリー上の親を取得または設定します。
+    /// ルートまたはツリーから切り離されたElementでは<see langword="null"/>です。
+    /// </summary>
     public Element? Parent { get; set; }
 
+    /// <summary>
+    /// Elementツリー上の深さを取得または設定します。
+    /// ルートを1とし、子へ進むごとに1ずつ増加します。
+    /// </summary>
     public int Depth { get; set; }
 
+    /// <summary>
+    /// このElement以下で最初に見つかるRenderObjectを取得します。
+    /// 対応するRenderObjectが存在しない場合は<see langword="null"/>です。
+    /// </summary>
+    /// <seealso cref="RenderObjectElement"/>
     public virtual RenderObject? RenderObject
     {
         get
@@ -36,10 +58,21 @@ public abstract class Element : IBuildContext, IComparable<Element>
         protected set => field = value;
     }
 
+    /// <summary>
+    /// このElementから参照できるInheritedWidgetの登録型と、最近傍の対応Elementとのマップを取得または設定します。
+    /// 継承情報がまだ構成されていない場合は<see langword="null"/>です。
+    /// </summary>
     public Dictionary<Type, InheritedElement>? InheritedWidgets { get; set; }
 
+    /// <summary>
+    /// このElementが依存関係を登録したInheritedElementの集合を取得します。
+    /// </summary>
     protected HashSet<InheritedElement> Dependencies { get; } = [];
 
+    /// <summary>
+    /// このElementツリーの再構築を管理する所有者を取得または設定します。
+    /// ツリーへ接続されていない場合は<see langword="null"/>です。
+    /// </summary>
     public BuildOwner? Owner { get; set; }
 
     private InheritedWidget DependOnInheritedElement(InheritedElement ancestor)
@@ -49,6 +82,7 @@ public abstract class Element : IBuildContext, IComparable<Element>
         return ancestor.Widget as InheritedWidget;
     }
 
+    /// <inheritdoc/>
     public T? DependOnInheritedWidgetOfExactType<T>() where T : InheritedWidget
     {
         if (InheritedWidgets?.TryGetValue(typeof(T), out var ancestor) ?? false)
@@ -59,6 +93,7 @@ public abstract class Element : IBuildContext, IComparable<Element>
         return null;
     }
 
+    /// <inheritdoc/>
     public virtual InheritedElement? GetElementForInheritedWidgetOfExactType<T>() where T : InheritedWidget
     {
         if (InheritedWidgets?.TryGetValue(typeof(T), out var inheritedElement) ?? false)
@@ -69,13 +104,36 @@ public abstract class Element : IBuildContext, IComparable<Element>
         return null;
     }
 
+    /// <summary>
+    /// 親Elementから、このElementで参照可能なInheritedWidgetのマップを引き継ぎます。
+    /// </summary>
     protected virtual void UpdateInheritance() => InheritedWidgets = Parent?.InheritedWidgets;
 
+    /// <summary>
+    /// このElementが<see cref="BuildOwner"/>の再構築待ちリストに登録されているかどうかを取得または設定します。
+    /// </summary>
+    /// <remarks>この値を直接変更しても、再構築は予約されません。</remarks>
     public bool InDirtyList { get; set; }
+    /// <summary>
+    /// このElementが再構築を必要としているかどうかを取得または設定します。
+    /// </summary>
+    /// <remarks>再構築を予約する場合は、この値を直接設定せず<see cref="MarkNeedsBuild"/>を使用します。</remarks>
     public bool Dirty { get; set; }
 
+    /// <summary>
+    /// このElementが直接管理する子Elementを列挙します。
+    /// </summary>
+    /// <param name="visitor">各子Elementに一度ずつ適用する処理。</param>
     public virtual void VisitChildren(Action<Element> visitor) { }
 
+    /// <summary>
+    /// このElementを指定した親の子としてElementツリーへ接続します。
+    /// </summary>
+    /// <param name="parent">接続先の親Element。ルートとして接続する場合は<see langword="null"/>。</param>
+    /// <remarks>
+    /// 親から所有者と継承情報を引き継ぎ、深さを設定します。
+    /// このメソッドだけではWidgetの再構築やRenderObjectの接続は行いません。
+    /// </remarks>
     public virtual void Mount(Element? parent)
     {
         Parent = parent;
@@ -90,6 +148,12 @@ public abstract class Element : IBuildContext, IComparable<Element>
     }
 
 
+    /// <summary>
+    /// 既存の子Elementを新しいWidget構成へ更新し、再利用できない場合は子Elementを置き換えます。
+    /// </summary>
+    /// <param name="child">現在の子Element。子が存在しない場合は<see langword="null"/>。</param>
+    /// <param name="newWidget">子として適用するWidget。子を取り除く場合は<see langword="null"/>。</param>
+    /// <returns>更新または生成された子Element。子を取り除いた場合は<see langword="null"/>。</returns>
     protected Element? UpdateChild(Element? child, Widget? newWidget)
     {
         if (newWidget == null)
@@ -121,9 +185,19 @@ public abstract class Element : IBuildContext, IComparable<Element>
         return InflateWidget(newWidget);
     }
 
+    /// <summary>
+    /// このElementが管理するWidgetを、更新後の構成へ置き換えます。
+    /// </summary>
+    /// <param name="newWidget">このElementと同じ位置を引き継ぐ新しいWidget。</param>
+    /// <remarks>基底実装はWidgetの置き換えだけを行い、再構築を予約しません。</remarks>
     public virtual void Update(Widget newWidget) => Widget = newWidget;
 
 
+    /// <summary>
+    /// 指定したWidgetに対応するElementを生成し、このElementの子としてマウントします。
+    /// </summary>
+    /// <param name="newWidget">Elementを生成するWidget。</param>
+    /// <returns>生成してマウントされた子Element。</returns>
     protected Element InflateWidget(Widget newWidget)
     {
         var newChild = newWidget.CreateElement();
@@ -134,13 +208,23 @@ public abstract class Element : IBuildContext, IComparable<Element>
         return newChild;
     }
 
+    /// <summary>
+    /// このElement以下のRenderObjectを、祖先側のRenderObjectツリーへ接続します。
+    /// </summary>
     public virtual void AttachRenderObject() { }
 
+    /// <summary>
+    /// このElement以下のRenderObjectをRenderObjectツリーから切り離します。
+    /// </summary>
     public virtual void DetachRenderObject()
     {
         VisitChildren(child => child.DetachRenderObject());
     }
 
+    /// <summary>
+    /// 指定した子ElementをElementツリーとRenderObjectツリーから切り離し、依存関係を解除します。
+    /// </summary>
+    /// <param name="child">切り離す直接の子Element。</param>
     protected void DeactivateChild(Element child)
     {
         child.Parent = null;
@@ -166,8 +250,19 @@ public abstract class Element : IBuildContext, IComparable<Element>
         VisitChildren(child => child.Deactivate());
     }
 
+    /// <summary>
+    /// このElementが依存するInheritedWidgetの値が変更されたことを通知します。
+    /// </summary>
+    /// <remarks>基底実装はこのElementの再構築を要求します。</remarks>
     public virtual void DidChangeDependencies() => MarkNeedsBuild();
 
+    /// <summary>
+    /// このElementを次のビルド処理で再構築するよう要求します。
+    /// </summary>
+    /// <remarks>
+    /// Elementを再構築が必要な状態にし、所有者の再構築待ちリストへ登録します。
+    /// すでに再構築が必要な場合は、状態と予約を変更しません。
+    /// </remarks>
     public void MarkNeedsBuild()
     {
         if (Dirty) return;
@@ -186,10 +281,24 @@ public abstract class Element : IBuildContext, IComparable<Element>
         VisitChildren(child => child.Reassemble());
     }
 
+    /// <summary>
+    /// このElement固有の再構築処理を直ちに実行します。
+    /// </summary>
+    /// <remarks>通常のフレーム更新では<see cref="BuildOwner.BuildScope"/>から呼び出されます。</remarks>
     public void Rebuild() => PerformRebuild();
 
+    /// <summary>
+    /// 派生Elementが担当する再構築処理を実行します。
+    /// </summary>
     public abstract void PerformRebuild();
 
+    /// <summary>
+    /// Elementの再構築順序を、ツリーの深さと再構築要否に基づいて比較します。
+    /// </summary>
+    /// <param name="other">比較対象のElement。<see langword="null"/>は指定できません。</param>
+    /// <returns>
+    /// このElementが先なら負の値、同順位なら0、後なら正の値。
+    /// </returns>
     public int CompareTo(Element? other)
     {
         if (Depth < other.Depth) return -1;

--- a/src/FloatSoda/Elements/InheritedElement.cs
+++ b/src/FloatSoda/Elements/InheritedElement.cs
@@ -2,11 +2,22 @@
 
 namespace FloatSoda.Elements;
 
+/// <summary>
+/// InheritedWidgetを祖先マップへ登録し、その値に依存する子孫Elementへ変更を通知するElementです。
+/// </summary>
+/// <seealso cref="InheritedWidget"/>
 public class InheritedElement : ComponentElement
 {
     internal HashSet<Element> Dependents { get; } = [];
+    /// <summary>
+    /// 管理しているInheritedWidgetの子Widgetを返します。
+    /// </summary>
+    /// <returns>InheritedWidgetが公開する子Widget。</returns>
     public override Widget Build() => (Widget as InheritedWidget)!.Child;
 
+    /// <summary>
+    /// 親から継承した祖先マップを複製し、このInheritedWidgetを登録型の最近傍要素として追加します。
+    /// </summary>
     protected override void UpdateInheritance()
     {
         var incomingWidgets = Parent?.InheritedWidgets;
@@ -19,10 +30,25 @@ public class InheritedElement : ComponentElement
         InheritedWidgets[((InheritedWidget)Widget!).ScopeType] = this;
     }
 
+    /// <summary>
+    /// 指定したElementを、このInheritedWidgetの変更通知先として登録します。
+    /// </summary>
+    /// <param name="dependent">このInheritedWidgetの値に依存するElement。</param>
     public void UpdateDependencies(Element dependent) => Dependents.Add(dependent);
 
+    /// <summary>
+    /// 指定したElementを、このInheritedWidgetの変更通知先から除外します。
+    /// </summary>
+    /// <param name="dependent">依存関係を解除するElement。</param>
     public void RemoveDependent(Element dependent) => Dependents.Remove(dependent);
 
+    /// <summary>
+    /// 管理するInheritedWidgetを置き換え、通知条件を満たす場合は登録済みの依存Elementへ変更を通知します。
+    /// </summary>
+    /// <param name="newWidget">同じスコープを引き継ぐ新しいInheritedWidget。</param>
+    /// <remarks>
+    /// 更新後はこのElementを再構築し、依存先へ通知した場合は各依存Elementにも再構築を要求します。
+    /// </remarks>
     public override void Update(Widget newWidget)
     {
         var oldWidget = Widget as InheritedWidget;

--- a/src/FloatSoda/Elements/LeafRenderObjectElement.cs
+++ b/src/FloatSoda/Elements/LeafRenderObjectElement.cs
@@ -1,5 +1,8 @@
 ﻿namespace FloatSoda.Elements;
 
+/// <summary>
+/// 子を持たないRenderObjectに対応するElementとして使用する型です。
+/// </summary>
 public class LeafRenderObjectElement
 {
     

--- a/src/FloatSoda/Elements/MultiChildRenderObjectElement.cs
+++ b/src/FloatSoda/Elements/MultiChildRenderObjectElement.cs
@@ -3,33 +3,53 @@ using FloatSoda.Widgets;
 
 namespace FloatSoda.Elements;
 
+/// <summary>
+/// 複数の子Widgetを持つRenderObjectWidgetを、複数の子RenderObjectへ対応付けるElementです。
+/// </summary>
+/// <typeparam name="T">このElementが管理するRenderObjectの型。</typeparam>
+/// <seealso cref="MultiChildRenderObjectWidget{T}"/>
 public class MultiChildRenderObjectElement<T> : RenderObjectElement<T> where T : RenderObject
 {
+    /// <summary>
+    /// このElementが現在管理している複数子用Widgetを取得します。
+    /// </summary>
     public MultiChildRenderObjectWidget<T> WidgetCasted => (MultiChildRenderObjectWidget<T>)Widget!;
 
     private List<Element> Children { get; set; } = [];
 
+    /// <inheritdoc/>
     public override RenderObject? RenderObject { get; protected set; }
 
+    /// <summary>
+    /// ElementツリーとRenderObjectツリーへ接続し、Widgetが宣言するすべての子Elementを生成します。
+    /// </summary>
+    /// <param name="parent">接続先の親Element。ルートとして接続する場合は<see langword="null"/>。</param>
     public override void Mount(Element? parent)
     {
         base.Mount(parent);
         Children = WidgetCasted.Children.Select(InflateWidget).ToList();
     }
 
+    /// <summary>
+    /// 管理するWidgetを置き換え、キーとWidget型に基づいて既存の子Elementを再利用しながら子一覧を更新します。
+    /// </summary>
+    /// <param name="newWidget">同じRenderObjectを引き継ぐ新しい複数子用Widget。</param>
     public override void Update(Widget newWidget)
     {
         base.Update(newWidget);
         Children = UpdateChildren(Children, WidgetCasted.Children);
     }
 
+    /// <inheritdoc/>
     public override void VisitChildren(Action<Element> visitor) => Children.ForEach(visitor);
 
+    /// <inheritdoc/>
     public override void InsertRenderObjectChild(RenderObject child)
     {
         if (RenderObject is IHasMultiChildrenRenderObject ro) ro.AddChild(child);
     }
 
+    /// <inheritdoc/>
     public override void RemoveRenderObjectChild(RenderObject? child)
     {
         if (child != null && RenderObject is IHasMultiChildrenRenderObject ro) ro.RemoveChild(child);

--- a/src/FloatSoda/Elements/RenderObjectElement.cs
+++ b/src/FloatSoda/Elements/RenderObjectElement.cs
@@ -3,11 +3,18 @@ using FloatSoda.Widgets;
 
 namespace FloatSoda.Elements;
 
+/// <summary>
+/// 対応するRenderObjectを祖先のRenderObjectツリーへ接続するElementの基底クラスです。
+/// </summary>
+/// <seealso cref="RenderObject"/>
 public abstract class RenderObjectElement : Element
 {
     private RenderObjectElement? _ancestorRenderObjectElement;
 
 
+    /// <summary>
+    /// 最近傍の祖先RenderObjectElementへ、このElementのRenderObjectを子として接続します。
+    /// </summary>
     public override void AttachRenderObject()
     {
         _ancestorRenderObjectElement = FindAncestorRenderObjectElement();
@@ -15,6 +22,9 @@ public abstract class RenderObjectElement : Element
     }
 
 
+    /// <summary>
+    /// 接続先として記録された祖先RenderObjectElementから、このElementのRenderObjectを切り離します。
+    /// </summary>
     public override void DetachRenderObject()
     {
         if (_ancestorRenderObjectElement == null) return;
@@ -23,12 +33,26 @@ public abstract class RenderObjectElement : Element
     }
 
 
+    /// <summary>
+    /// このElementのRenderObjectへ子RenderObjectを挿入します。
+    /// </summary>
+    /// <param name="child">挿入する子RenderObject。子を持たないことを表す場合は<see langword="null"/>。</param>
     public virtual void InsertRenderObjectChild(RenderObject? child) { }
 
 
+    /// <summary>
+    /// このElementのRenderObjectから子RenderObjectを取り除きます。
+    /// </summary>
+    /// <param name="child">取り除く子RenderObject。対象がない場合は<see langword="null"/>。</param>
     public virtual void RemoveRenderObjectChild(RenderObject? child) { }
 
 
+    /// <summary>
+    /// Elementツリーを親方向へ探索し、最も近いRenderObjectElementを取得します。
+    /// </summary>
+    /// <returns>
+    /// 最も近い祖先のRenderObjectElement。該当する祖先が存在しない場合は<see langword="null"/>。
+    /// </returns>
     public RenderObjectElement? FindAncestorRenderObjectElement()
     {
         var ancestor = Parent;
@@ -41,6 +65,15 @@ public abstract class RenderObjectElement : Element
         return ancestor as RenderObjectElement;
     }
 
+    /// <summary>
+    /// 複数の子Elementを新しいWidget一覧へ更新し、型とキーが一致する子を再利用します。
+    /// </summary>
+    /// <param name="oldChildren">更新前の子Element一覧。</param>
+    /// <param name="newWidgets">更新後に子として構成するWidget一覧。</param>
+    /// <param name="forgottenChildren">
+    /// 再利用候補から除外する子Elementの集合。除外する子がない場合は<see langword="null"/>。
+    /// </param>
+    /// <returns>新しいWidget一覧と同じ順序で構成された更新後の子Element一覧。</returns>
     protected List<Element> UpdateChildren(
         List<Element> oldChildren,
         List<Widget> newWidgets,
@@ -152,12 +185,25 @@ public abstract class RenderObjectElement : Element
     }
 }
 
+/// <summary>
+/// 指定した型のRenderObjectを生成・更新するRenderObjectWidgetに対応するElementの基底クラスです。
+/// </summary>
+/// <typeparam name="T">このElementが管理するRenderObjectの型。</typeparam>
+/// <seealso cref="RenderObjectWidget{T}"/>
 public abstract class RenderObjectElement<T> : RenderObjectElement where T : RenderObject
 {
+    /// <summary>
+    /// このElementが管理するRenderObjectを取得します。
+    /// RenderObjectがまだ生成されていない場合は<see langword="null"/>です。
+    /// </summary>
     public abstract override RenderObject? RenderObject { get; protected set; }
     private RenderObjectWidget<T>? WidgetCascaded => Widget as RenderObjectWidget<T>;
 
 
+    /// <summary>
+    /// Elementツリーへ接続し、対応するWidgetからRenderObjectを生成してRenderObjectツリーへ接続します。
+    /// </summary>
+    /// <param name="parent">接続先の親Element。ルートとして接続する場合は<see langword="null"/>。</param>
     public override void Mount(Element? parent)
     {
         base.Mount(parent);
@@ -167,6 +213,10 @@ public abstract class RenderObjectElement<T> : RenderObjectElement where T : Ren
     }
 
 
+    /// <summary>
+    /// 管理するWidgetを置き換え、その構成を既存のRenderObjectへ直ちに反映します。
+    /// </summary>
+    /// <param name="newWidget">同じRenderObjectを引き継ぐ新しいWidget。</param>
     public override void Update(Widget newWidget)
     {
         base.Update(newWidget);
@@ -174,6 +224,9 @@ public abstract class RenderObjectElement<T> : RenderObjectElement where T : Ren
     }
 
 
+    /// <summary>
+    /// 現在のWidgetの構成を管理対象のRenderObjectへ反映し、再構築が必要な状態を解除します。
+    /// </summary>
     public override void PerformRebuild()
     {
         WidgetCascaded?.UpdateRenderObject(RenderObject as T);

--- a/src/FloatSoda/Elements/RenderObjectToWidgetElement.cs
+++ b/src/FloatSoda/Elements/RenderObjectToWidgetElement.cs
@@ -3,17 +3,35 @@ using FloatSoda.Widgets;
 
 namespace FloatSoda.Elements;
 
+/// <summary>
+/// 既存のRenderObjectをルートとしてWidgetツリーを接続するアダプターに対応するElementです。
+/// </summary>
+/// <typeparam name="T">ルートとして使用するRenderObjectの型。</typeparam>
+/// <seealso cref="RenderObjectToWidgetAdapter"/>
 public class RenderObjectToWidgetElement<T> : RenderObjectElement<T> where T : RenderObject
 {
+    /// <summary>
+    /// 次の再構築時に適用する新しいルートWidgetを取得または設定します。
+    /// 保留中の更新がない場合は<see langword="null"/>です。
+    /// </summary>
+    /// <remarks>値は再構築時に一度だけ消費され、適用前に<see langword="null"/>へ戻されます。</remarks>
     public Widget? NewWidget { get; set; }
     private Element? Child { get; set; }
 
+    /// <summary>
+    /// ElementツリーとRenderObjectツリーへ接続し、アダプターが宣言する子Elementを生成します。
+    /// </summary>
+    /// <param name="parent">接続先の親Element。ルートとして接続する場合は<see langword="null"/>。</param>
     public override void Mount(Element? parent)
     {
         base.Mount(parent);
         OnRebuild();
     }
 
+    /// <summary>
+    /// ルートのアダプターWidgetを置き換え、その子Elementを更新します。
+    /// </summary>
+    /// <param name="newWidget">既存のルートRenderObjectを引き継ぐ新しいアダプターWidget。</param>
     public override void Update(Widget newWidget)
     {
         base.Update(newWidget);
@@ -22,6 +40,9 @@ public class RenderObjectToWidgetElement<T> : RenderObjectElement<T> where T : R
 
     private void OnRebuild() => Child = UpdateChild(Child, (Widget as RenderObjectToWidgetAdapter)?.Child);
 
+    /// <summary>
+    /// 保留中のルートWidget更新を適用した後、現在の構成をルートRenderObjectへ反映します。
+    /// </summary>
     public override void PerformRebuild()
     {
         if (NewWidget is not null)
@@ -34,13 +55,16 @@ public class RenderObjectToWidgetElement<T> : RenderObjectElement<T> where T : R
         base.PerformRebuild();
     }
 
+    /// <inheritdoc/>
     public override RenderObject? RenderObject { get; protected set; }
 
+    /// <inheritdoc/>
     public override void InsertRenderObjectChild(RenderObject? child)
     {
         if (RenderObject is IHasSingleChildRenderObject ro) ro.Child = child;
     }
 
+    /// <inheritdoc/>
     public override void VisitChildren(Action<Element> visitor)
     {
         if (Child != null) visitor(Child);

--- a/src/FloatSoda/Elements/SingleChildRenderObjectElement.cs
+++ b/src/FloatSoda/Elements/SingleChildRenderObjectElement.cs
@@ -3,14 +3,28 @@ using FloatSoda.Widgets;
 
 namespace FloatSoda.Elements;
 
+/// <summary>
+/// 単一の子Widgetを持つRenderObjectWidgetを、単一の子RenderObjectへ対応付けるElementです。
+/// </summary>
+/// <typeparam name="T">このElementが管理するRenderObjectの型。</typeparam>
+/// <seealso cref="SingleChildRenderObjectWidget{T}"/>
 public class SingleChildRenderObjectElement<T> : RenderObjectElement<T> where T : RenderObject
 {
+    /// <summary>
+    /// このElementが現在管理している単一子用Widgetを取得します。
+    /// Widgetが割り当てられていない場合、または型が一致しない場合は<see langword="null"/>です。
+    /// </summary>
     public SingleChildRenderObjectWidget<T>? WidgetCasted => Widget as SingleChildRenderObjectWidget<T>;
 
     private Element? Child { get; set; }
 
+    /// <inheritdoc/>
     public override RenderObject? RenderObject { get; protected set; }
 
+    /// <summary>
+    /// ElementツリーとRenderObjectツリーへ接続し、Widgetが宣言する子Elementを生成します。
+    /// </summary>
+    /// <param name="parent">接続先の親Element。ルートとして接続する場合は<see langword="null"/>。</param>
     public override void Mount(Element? parent)
     {
         base.Mount(parent);
@@ -18,22 +32,29 @@ public class SingleChildRenderObjectElement<T> : RenderObjectElement<T> where T 
     }
 
 
+    /// <summary>
+    /// 管理するWidgetを置き換え、Widget型とキーが一致する場合は既存の子Elementを再利用して子を更新します。
+    /// </summary>
+    /// <param name="newWidget">同じRenderObjectを引き継ぐ新しい単一子用Widget。</param>
     public override void Update(Widget newWidget)
     {
         base.Update(newWidget);
         Child = UpdateChild(Child, WidgetCasted?.Child);
     }
 
+    /// <inheritdoc/>
     public override void InsertRenderObjectChild(RenderObject? child)
     {
         if (RenderObject is IHasSingleChildRenderObject ro) ro.Child = child;
     }
 
+    /// <inheritdoc/>
     public override void RemoveRenderObjectChild(RenderObject? child)
     {
         if (RenderObject is IHasSingleChildRenderObject ro) ro.Child = null;
     }
 
+    /// <inheritdoc/>
     public override void VisitChildren(Action<Element> visitor)
     {
         if (Child != null) visitor(Child);

--- a/src/FloatSoda/RenderObjects/PaintingContext.cs
+++ b/src/FloatSoda/RenderObjects/PaintingContext.cs
@@ -4,13 +4,27 @@ using SkiaSharp;
 
 namespace FloatSoda.RenderObjects;
 
+/// <summary>RenderObjectの描画命令を画像レイヤーと合成レイヤーへ記録します。</summary>
+/// <param name="containerLayer">生成した子レイヤーを追加するコンテナレイヤー。</param>
+/// <param name="estimatedBounds">画像の記録に使用する推定描画範囲。</param>
+/// <remarks>一つのインスタンスは一つのコンテナレイヤーへ記録し、必要に応じて子用のコンテキストを生成します。</remarks>
 public class PaintingContext(ContainerLayer containerLayer, SKRect estimatedBounds)
 {
+    /// <summary>現在記録中の画像レイヤーです。</summary>
     private PictureLayer? _currentLayer;
+
+    /// <summary>現在の画像を構築する記録器です。</summary>
     private SKPictureRecorder? _recorder;
+
+    /// <summary>現在の画像へ描画命令を記録するキャンバスです。</summary>
     private SKCanvas? _canvas;
+
+    /// <summary>画像への描画命令を記録中かどうかを取得します。</summary>
     private bool IsRecording => _canvas != null;
 
+    /// <summary>描画命令を記録するキャンバスを取得します。</summary>
+    /// <value>このコンテキストの現在の画像へ記録するキャンバス。</value>
+    /// <remarks>最初の取得時に画像レイヤーと記録器を生成し、対象のコンテナレイヤーへ画像レイヤーを追加します。</remarks>
     public SKCanvas Canvas
     {
         get
@@ -20,6 +34,8 @@ public class PaintingContext(ContainerLayer containerLayer, SKRect estimatedBoun
         }
     }
 
+    /// <summary>新しい画像レイヤーへの描画記録を開始します。</summary>
+    /// <remarks>生成した画像レイヤーを対象のコンテナレイヤーへ直ちに追加します。</remarks>
     private void StartRecording()
     {
         _currentLayer = new PictureLayer();
@@ -28,6 +44,8 @@ public class PaintingContext(ContainerLayer containerLayer, SKRect estimatedBoun
         _canvas = _recorder.BeginRecording(estimatedBounds);
     }
 
+    /// <summary>描画記録中であれば画像を確定して記録を終了します。</summary>
+    /// <remarks>記録していない場合は何もしません。確定した画像は現在の画像レイヤーへ設定されます。</remarks>
     public void StopRecordingIfNeeded()
     {
         if (!IsRecording) return;
@@ -38,6 +56,15 @@ public class PaintingContext(ContainerLayer containerLayer, SKRect estimatedBoun
         _canvas = null;
     }
 
+    /// <summary>子のコンテナレイヤーへ描画内容を記録します。</summary>
+    /// <param name="childLayer">描画内容を保持する子レイヤー。既存の子レイヤーは消去して再利用されます。</param>
+    /// <param name="painter">子用の描画コンテキストへ描画命令を記録する処理。</param>
+    /// <param name="offset">親の座標系における子の描画原点。</param>
+    /// <param name="childPaintBounds">子の推定描画範囲。省略した場合はこのコンテキストの推定描画範囲を使用します。</param>
+    /// <remarks>
+    /// 現在の画像記録を確定してから子レイヤーを対象のコンテナへ追加します。
+    /// 描画処理の完了後、子コンテキストに残る画像記録も確定します。
+    /// </remarks>
     public void PushLayer(
         ContainerLayer childLayer,
         Action<PaintingContext, Offset> painter,
@@ -58,6 +85,12 @@ public class PaintingContext(ContainerLayer containerLayer, SKRect estimatedBoun
         childContext.StopRecordingIfNeeded();
     }
 
+    /// <summary>子の描画へ不透明度を適用する合成レイヤーを追加します。</summary>
+    /// <param name="offset">親の座標系における子の描画原点。</param>
+    /// <param name="alpha">不透明度。0は完全な透明、255は完全な不透明を表します。</param>
+    /// <param name="painter">不透明度レイヤー内へ描画命令を記録する処理。</param>
+    /// <param name="oldLayer">再利用する既存レイヤー。新しく生成する場合は<see langword="null"/>です。</param>
+    /// <returns>描画内容を保持する不透明度レイヤー。</returns>
     public OpacityLayer PushOpacity(
         Offset offset,
         byte alpha,
@@ -73,6 +106,15 @@ public class PaintingContext(ContainerLayer containerLayer, SKRect estimatedBoun
         return layer;
     }
 
+    /// <summary>任意形状で子の描画を切り抜く合成レイヤーを追加します。</summary>
+    /// <param name="offset">親の座標系における子の描画原点。</param>
+    /// <param name="bounds">子のローカル座標系における推定描画範囲。</param>
+    /// <param name="clipPath">子のローカル座標系で定義された切り抜き形状。元の形状は変更しません。</param>
+    /// <param name="painter">切り抜きレイヤー内へ描画命令を記録する処理。</param>
+    /// <param name="clipBehavior">境界の描画方法。</param>
+    /// <param name="oldLayer">再利用する既存レイヤー。新しく生成する場合は<see langword="null"/>です。</param>
+    /// <returns>描画内容を保持するパス切り抜きレイヤー。</returns>
+    /// <remarks>描画範囲と切り抜き形状を<paramref name="offset"/>だけ移動して親の座標系へ変換します。</remarks>
     public ClipPathLayer PushClipPath(
         Offset offset,
         SKRect bounds,
@@ -98,6 +140,15 @@ public class PaintingContext(ContainerLayer containerLayer, SKRect estimatedBoun
         return layer;
     }
 
+    /// <summary>角丸矩形で子の描画を切り抜く合成レイヤーを追加します。</summary>
+    /// <param name="offset">親の座標系における子の描画原点。</param>
+    /// <param name="bounds">子のローカル座標系における推定描画範囲。</param>
+    /// <param name="clipRect">子のローカル座標系で定義された角丸矩形。</param>
+    /// <param name="painter">切り抜きレイヤー内へ描画命令を記録する処理。</param>
+    /// <param name="clipBehavior">境界の描画方法。</param>
+    /// <param name="oldLayer">再利用する既存レイヤー。新しく生成する場合は<see langword="null"/>です。</param>
+    /// <returns>描画内容を保持する角丸矩形切り抜きレイヤー。</returns>
+    /// <remarks>切り抜き矩形を<paramref name="offset"/>だけ移動して親の座標系へ変換します。</remarks>
     public ClipRoundRectLayer PushClipRoundRect(
         Offset offset,
         SKRect bounds,
@@ -121,6 +172,14 @@ public class PaintingContext(ContainerLayer containerLayer, SKRect estimatedBoun
         return layer;
     }
 
+    /// <summary>矩形で子の描画を切り抜く合成レイヤーを追加します。</summary>
+    /// <param name="offset">親の座標系における子の描画原点。</param>
+    /// <param name="clipRect">子のローカル座標系で定義された切り抜き矩形。</param>
+    /// <param name="painter">切り抜きレイヤー内へ描画命令を記録する処理。</param>
+    /// <param name="clipBehavior">境界の描画方法。</param>
+    /// <param name="oldLayer">再利用する既存レイヤー。新しく生成する場合は<see langword="null"/>です。</param>
+    /// <returns>描画内容を保持する矩形切り抜きレイヤー。</returns>
+    /// <remarks>切り抜き矩形を<paramref name="offset"/>だけ移動して親の座標系へ変換します。</remarks>
     public ClipRectLayer PushClipRect(
         Offset offset,
         SKRect clipRect,
@@ -140,6 +199,13 @@ public class PaintingContext(ContainerLayer containerLayer, SKRect estimatedBoun
         return layer;
     }
 
+    /// <summary>子の描画内容を現在のレイヤーツリーへ記録します。</summary>
+    /// <param name="child">描画する子。</param>
+    /// <param name="offset">親の座標系における子の描画原点。</param>
+    /// <remarks>
+    /// 子が再描画境界の場合は現在の画像記録を確定し、子の独立したレイヤーを合成します。
+    /// 境界でない場合は子の描画Dirtyを解除して、現在のコンテキストへ直接描画します。
+    /// </remarks>
     public void PaintChild(RenderObject child, Offset offset)
     {
         if (child.IsRepaintBoundary)
@@ -154,6 +220,13 @@ public class PaintingContext(ContainerLayer containerLayer, SKRect estimatedBoun
         }
     }
 
+    /// <summary>再描画境界である子のレイヤーを現在のレイヤーツリーへ合成します。</summary>
+    /// <param name="child">独立した合成レイヤーを持つ子。</param>
+    /// <param name="offset">親の座標系における子の描画原点。</param>
+    /// <remarks>
+    /// 子が描画Dirtyの場合は先に子のレイヤーを再描画します。
+    /// 子のレイヤーが移動レイヤーでない場合は現在のレイヤーツリーへ追加しません。
+    /// </remarks>
     public void CompositeChild(RenderObject child, Offset offset)
     {
         if (child.NeedsPaint)
@@ -167,6 +240,12 @@ public class PaintingContext(ContainerLayer containerLayer, SKRect estimatedBoun
         containerLayer.Children.Add(childTransformLayer);
     }
 
+    /// <summary>再描画境界であるRenderObjectの合成レイヤーを再構築します。</summary>
+    /// <param name="child">再描画するRenderObject。</param>
+    /// <remarks>
+    /// 既存の移動レイヤーがあれば子レイヤーを消去して再利用し、なければ新しく生成して<see cref="RenderObject.Layer"/>へ設定します。
+    /// 描画前に対象の描画Dirtyを解除し、対象の原点を基準として描画内容を記録します。
+    /// </remarks>
     public static void RepaintCompositedChild(RenderObject child)
     {
         if (child.Layer is not TransformLayer childLayer)

--- a/src/FloatSoda/RenderObjects/ParentData.cs
+++ b/src/FloatSoda/RenderObjects/ParentData.cs
@@ -2,9 +2,18 @@
 
 namespace FloatSoda.RenderObjects;
 
+/// <summary>親RenderObjectが子ごとに保持する配置情報を表すインターフェースです。</summary>
 public interface IParentData;
 
+/// <summary>ボックスレイアウト内で子の配置位置を保持します。</summary>
+/// <param name="offset">親の座標系における子の初期位置。</param>
 public class BoxParentData(Offset offset = default) : IParentData
 {
+    /// <summary>親の座標系における子の配置位置を取得または設定します。</summary>
+    /// <value>親の描画原点から子の描画原点までの移動量。</value>
+    /// <remarks>
+    /// この値自体はDirty状態を変更しません。
+    /// 親は値を変更したレイアウト処理と同じパイプライン更新内で、後続の描画に新しい位置を使用します。
+    /// </remarks>
     public Offset Offset { get; set; } = offset;
 }

--- a/src/FloatSoda/RenderObjects/RenderBox.cs
+++ b/src/FloatSoda/RenderObjects/RenderBox.cs
@@ -6,10 +6,20 @@ using SkiaSharp;
 
 namespace FloatSoda.RenderObjects;
 
+/// <summary>矩形のサイズを持ち、ボックス制約によるレイアウトとヒットテストを行うRenderObjectの基底クラスです。</summary>
 public abstract class RenderBox : RenderObject
 {
+    /// <inheritdoc/>
     public override SKSize Size { get; protected set; } = SKSize.Empty;
 
+    /// <summary>指定したローカル座標がこのRenderBoxまたはその子にヒットするかを判定します。</summary>
+    /// <param name="result">ヒットした対象を奥から手前の順に追加する結果。</param>
+    /// <param name="position">このRenderBoxのローカル座標系における判定位置。</param>
+    /// <returns>自身または子がヒットした場合は<see langword="true"/>、それ以外の場合は<see langword="false"/>です。</returns>
+    /// <remarks>
+    /// 位置が<see cref="Size"/>の範囲外の場合は子と自身を判定しません。
+    /// ヒットした場合は子の結果に続けて自身のエントリを追加します。
+    /// </remarks>
     public virtual bool HitTest(HitTestResult result, Offset position)
     {
         if (!Size.Contains(position)) return false;
@@ -21,36 +31,61 @@ public abstract class RenderBox : RenderObject
         return true;
     }
 
+    /// <summary>指定したローカル座標が子にヒットするかを判定します。</summary>
+    /// <param name="result">ヒットした子を追加する結果。</param>
+    /// <param name="position">このRenderBoxのローカル座標系における判定位置。</param>
+    /// <returns>子がヒットした場合は<see langword="true"/>、それ以外の場合は<see langword="false"/>です。</returns>
     public virtual bool HitTestChildren(HitTestResult result, Offset position) => false;
 
+    /// <summary>指定したローカル座標で自身がヒットするかを判定します。</summary>
+    /// <param name="position">このRenderBoxのローカル座標系における判定位置。</param>
+    /// <returns>自身がヒット対象の場合は<see langword="true"/>、それ以外の場合は<see langword="false"/>です。</returns>
     public virtual bool HitTestSelf(Offset position) => false;
 
+    /// <summary>このRenderBoxへ配信されたポインターイベントを処理します。</summary>
+    /// <param name="pointerEvent">配信されたポインターイベント。</param>
+    /// <param name="entry">このRenderBoxに対応するヒットテスト結果。</param>
+    /// <remarks>既定の実装はイベントを処理しません。</remarks>
     public override void HandleEvent(PointerEvent pointerEvent, HitTestEntry entry)
     {
         // do nothing
     }
 }
 
+/// <summary>単一の子へレイアウト、描画、ヒットテストを委譲するRenderBoxの基底クラスです。</summary>
 public abstract class RenderProxyBox : RenderBox, IHasSingleChildRenderObject
 {
+    /// <summary>子の親子関係と接続ライフサイクルを管理するコンテナです。</summary>
     private readonly SingleChildContainer<RenderBox> _child;
 
+    /// <summary>子を持たないRenderProxyBoxを初期化します。</summary>
     protected RenderProxyBox() => _child = new SingleChildContainer<RenderBox>(this);
 
+    /// <summary>レイアウト、描画、ヒットテストを委譲する子を取得または設定します。</summary>
+    /// <value>保持する子。子を持たない場合は<see langword="null"/>です。</value>
+    /// <remarks>
+    /// 値を設定すると旧子をレンダーツリーから取り外し、新しい子を組み込みます。
+    /// その過程でこのRenderObjectがレイアウトDirtyになり、次のパイプライン更新時にサイズが再計算されます。
+    /// </remarks>
     public RenderBox? Child
     {
         get => _child.Child;
         set => _child.Child = value;
     }
 
+    /// <inheritdoc/>
     RenderObject? IHasSingleChildRenderObject.Child
     {
         get => Child;
         set => Child = (RenderBox?)value;
     }
 
+    /// <summary>子へボックス配置用の親データを割り当てます。</summary>
+    /// <param name="child">このRenderProxyBoxへ組み込む子。</param>
     public override void SetupParentData(RenderObject child) => child.ParentData = new BoxParentData();
 
+    /// <summary>子を現在の制約でレイアウトし、そのサイズを自身へ反映します。</summary>
+    /// <remarks>子が存在しない場合は、現在の制約で許される最小サイズを使用します。</remarks>
     public override void PerformLayout()
     {
         if (Child != null)
@@ -64,27 +99,42 @@ public abstract class RenderProxyBox : RenderBox, IHasSingleChildRenderObject
         }
     }
 
+    /// <summary>子を指定した位置へ描画します。</summary>
+    /// <param name="context">描画命令と合成レイヤーを記録するコンテキスト。</param>
+    /// <param name="offset">親の座標系における描画原点。</param>
+    /// <remarks>子が存在しない場合は何も記録しません。</remarks>
     public override void Paint(PaintingContext context, Offset offset)
     {
         if (Child != null) context.PaintChild(Child, offset);
     }
 
+    /// <summary>このRenderProxyBoxと子を指定した描画パイプラインへ接続します。</summary>
+    /// <param name="owner">接続先のパイプライン。パイプラインを関連付けずに接続する場合は<see langword="null"/>です。</param>
+    /// <remarks>自身に対するDirty状態の再登録後、同じ接続先を子へ伝播します。</remarks>
     public override void Attach(RenderPipeline? owner)
     {
         base.Attach(owner);
         _child.Attach(owner);
     }
 
+    /// <summary>このRenderProxyBoxと子を描画パイプラインから切り離します。</summary>
     public override void Detach()
     {
         base.Detach();
         _child.Detach();
     }
 
+    /// <summary>保持している子に処理を適用します。</summary>
+    /// <param name="visitor">子が存在する場合に一度適用する処理。</param>
     public override void VisitChildren(Action<RenderObject> visitor) => _child.VisitChildren(visitor);
 
+    /// <summary>保持している子とその子孫の深さを更新します。</summary>
     public override void RedepthChildren() => VisitChildren(RedepthChild);
 
+    /// <summary>指定したローカル座標が子にヒットするかを判定します。</summary>
+    /// <param name="result">ヒットした子を追加する結果。</param>
+    /// <param name="position">このRenderProxyBoxのローカル座標系における判定位置。</param>
+    /// <returns>子が存在してヒットした場合は<see langword="true"/>、それ以外の場合は<see langword="false"/>です。</returns>
     public override bool HitTestChildren(HitTestResult result, Offset position)
     {
         return Child?.HitTest(result, position) ?? false;

--- a/src/FloatSoda/RenderObjects/RenderObject.cs
+++ b/src/FloatSoda/RenderObjects/RenderObject.cs
@@ -9,35 +9,77 @@ using SkiaSharp;
 
 namespace FloatSoda.RenderObjects;
 
+/// <summary>
+/// レイアウト、描画、ヒットテストに参加するレンダーツリーの基底クラスです。
+/// </summary>
+/// <remarks>
+/// 親子関係とパイプラインへの接続状態を保持し、レイアウトDirtyおよび描画Dirtyを必要な境界まで伝播します。
+/// 派生型は<see cref="PerformLayout"/>、<see cref="Paint"/>、<see cref="HandleEvent"/>を実装します。
+/// </remarks>
 public abstract class RenderObject : IHitTestTarget
 {
+    /// <summary>直近のレイアウトに使用した制約を取得します。</summary>
     public BoxConstraints Constraints { get; private set; }
+
+    /// <summary>親がこのRenderObjectへ割り当てた配置情報を取得または設定します。</summary>
+    /// <value>親固有の配置情報。親へ組み込まれていない場合は<see langword="null"/>です。</value>
     public IParentData? ParentData { get; set; }
 
+    /// <summary>レンダーツリー上の親を取得または設定します。</summary>
+    /// <value>親RenderObject。ルートまたは親へ組み込まれていない場合は<see langword="null"/>です。</value>
     public RenderObject? Parent { get; set; }
 
+    /// <summary>このRenderObjectを管理する描画パイプラインを取得または設定します。</summary>
+    /// <value>接続先のパイプライン。デタッチ中は<see langword="null"/>です。</value>
     public RenderPipeline? Owner { get; set; }
 
+    /// <summary>このRenderObjectが保持する合成レイヤーを取得または設定します。</summary>
+    /// <value>再利用可能なレイヤー。レイヤーをまだ生成していない場合は<see langword="null"/>です。</value>
     public ILayer? Layer { get; set; }
 
+    /// <summary>レイアウトで決定されたサイズを取得します。</summary>
+    /// <value>このRenderObjectが占める論理ピクセル単位のサイズ。</value>
     public abstract SKSize Size { get; protected set; }
 
+    /// <summary>描画の再実行が必要かどうかを取得または設定します。</summary>
+    /// <value>描画Dirtyの場合は<see langword="true"/>、描画結果が最新の場合は<see langword="false"/>です。</value>
     public bool NeedsPaint { get; set; } = true;
 
+    /// <summary>レイアウトの再実行が必要かどうかを取得または設定します。</summary>
+    /// <value>レイアウトDirtyの場合は<see langword="true"/>、レイアウト結果が最新の場合は<see langword="false"/>です。</value>
     public bool NeedsLayout { get; set; } = true;
 
+    /// <summary>レンダーツリー内の深さを取得または設定します。</summary>
+    /// <value>ルートを0とした深さ。子は親より大きい値を持ちます。</value>
     public int Depth { get; set; } = 0;
 
+    /// <summary>このRenderObjectが再描画境界かどうかを取得します。</summary>
+    /// <value>独立した合成レイヤーへ描画する場合は<see langword="true"/>です。</value>
     public virtual bool IsRepaintBoundary { get; }
 
+    /// <summary>描画パイプラインへ接続されているかどうかを取得します。</summary>
     public bool Attached => Owner != null;
 
+    /// <summary>レイアウトDirtyの伝播が停止するRenderObjectを取得または設定します。</summary>
+    /// <value>再レイアウト境界。境界がまだ決定されていない場合は<see langword="null"/>です。</value>
     public RenderObject? RelayoutBoundary { get; set; }
 
+    /// <summary>親から渡された制約だけで自身のサイズを決定できるかどうかを取得します。</summary>
+    /// <value>子のレイアウト結果を参照せずにサイズを決定できる場合は<see langword="true"/>です。</value>
     public virtual bool SizedByParent { get; } = false;
 
+    /// <summary>現在の<see cref="Constraints"/>に従って自身と必要な子をレイアウトします。</summary>
+    /// <remarks>派生型は処理の完了前に<see cref="Size"/>を確定します。</remarks>
     public abstract void PerformLayout();
 
+    /// <summary>指定した制約でこのRenderObjectをレイアウトします。</summary>
+    /// <param name="constraints">サイズの有効範囲を定める制約。</param>
+    /// <param name="parentUseSize">親がこのRenderObjectの<see cref="Size"/>を使用する場合は<see langword="true"/>です。</param>
+    /// <remarks>
+    /// 制約、レイアウトDirty状態、再レイアウト境界のいずれも変化していない場合は何もしません。
+    /// レイアウト後はこのRenderObjectのレイアウトDirtyを解除し、描画Dirtyを再描画境界まで伝播します。
+    /// 再レイアウト境界が変化した場合は、境界に属していた子孫をレイアウトDirtyにします。
+    /// </remarks>
     public void Layout(BoxConstraints constraints, bool parentUseSize = false)
     {
         Debug.WriteLine("Call Layout");
@@ -64,6 +106,11 @@ public abstract class RenderObject : IHitTestTarget
         MarkNeedsPaint();
     }
 
+    /// <summary>現在の制約を変更せずにレイアウトを再実行します。</summary>
+    /// <remarks>
+    /// <see cref="RenderPipeline"/>が登録済みのレイアウトDirtyを処理するときに使用します。
+    /// レイアウト後はこのRenderObjectのレイアウトDirtyを解除し、描画Dirtyを再描画境界まで伝播します。
+    /// </remarks>
     public void LayoutWithoutResize()
     {
         PerformLayout();
@@ -73,6 +120,11 @@ public abstract class RenderObject : IHitTestTarget
         MarkNeedsPaint();
     }
 
+    /// <summary>子孫が保持する無効な再レイアウト境界を消去します。</summary>
+    /// <remarks>
+    /// 自身が再レイアウト境界でない場合、このRenderObjectをレイアウトDirtyにし、同じ処理を子孫へ伝播します。
+    /// 自身が再レイアウト境界の場合は伝播を停止します。
+    /// </remarks>
     public void CleanChildRelayoutBoundary()
     {
         if (RelayoutBoundary != this)
@@ -83,6 +135,12 @@ public abstract class RenderObject : IHitTestTarget
         }
     }
 
+    /// <summary>レイアウトの再実行を要求します。</summary>
+    /// <remarks>
+    /// すでにレイアウトDirtyの場合は何もしません。
+    /// 再レイアウト境界では自身をレイアウトDirtyとしてパイプラインへ登録し、表示更新を要求します。
+    /// 境界でない場合は親方向へ伝播し、最初の再レイアウト境界で登録されます。
+    /// </remarks>
     public void MarkNeedsLayout()
     {
         if (NeedsLayout) return;
@@ -98,6 +156,11 @@ public abstract class RenderObject : IHitTestTarget
         }
     }
 
+    /// <summary>このRenderObjectと親へレイアウトの再実行を要求します。</summary>
+    /// <remarks>
+    /// このRenderObjectをレイアウトDirtyにし、親の<see cref="MarkNeedsLayout"/>を通じて再レイアウト境界まで伝播します。
+    /// 親が存在しない場合、このメソッドだけではパイプラインへ登録されません。
+    /// </remarks>
     public void MarkParentNeedsLayout()
     {
         NeedsLayout = true;
@@ -105,6 +168,13 @@ public abstract class RenderObject : IHitTestTarget
     }
 
 
+    /// <summary>このRenderObjectを指定した描画パイプラインへ接続します。</summary>
+    /// <param name="owner">接続先のパイプライン。パイプラインを関連付けずに接続する場合は<see langword="null"/>です。</param>
+    /// <remarks>
+    /// 接続前からレイアウトDirtyで再レイアウト境界が設定済みの場合は、境界へレイアウト要求を登録し直します。
+    /// 描画Dirtyで既存レイヤーがある場合は、再描画境界へ描画要求を登録し直します。
+    /// 派生型は保持する子にも接続を伝播します。
+    /// </remarks>
     public virtual void Attach(RenderPipeline? owner)
     {
         Debug.WriteLine("Call Attach");
@@ -124,6 +194,12 @@ public abstract class RenderObject : IHitTestTarget
         MarkNeedsPaint();
     }
 
+    /// <summary>子をこのRenderObjectのレンダーツリーへ組み込みます。</summary>
+    /// <param name="child">組み込む子。別の親から事前に取り外されている必要があります。</param>
+    /// <remarks>
+    /// 子の親データを準備し、このRenderObjectへレイアウトDirtyを要求します。
+    /// 接続中の場合は子を同じパイプラインへ接続し、子孫の深さも更新します。
+    /// </remarks>
     public void AdoptChild(RenderObject child)
     {
         SetupParentData(child);
@@ -140,6 +216,9 @@ public abstract class RenderObject : IHitTestTarget
         RedepthChild(child);
     }
 
+    /// <summary>指定した子とその子孫の深さを必要に応じて更新します。</summary>
+    /// <param name="child">このRenderObjectの直下にある子。</param>
+    /// <remarks>子の深さがすでに親より大きい場合は何もしません。</remarks>
     public void RedepthChild(RenderObject child)
     {
         if (child.Depth <= Depth)
@@ -149,16 +228,33 @@ public abstract class RenderObject : IHitTestTarget
         }
     }
 
+    /// <summary>直下の子を起点として子孫の深さを更新します。</summary>
+    /// <remarks>子を保持する派生型がオーバーライドします。</remarks>
     public virtual void RedepthChildren() { }
 
+    /// <summary>直下の各子に処理を適用します。</summary>
+    /// <param name="visitor">各子に一度ずつ適用する処理。</param>
+    /// <remarks>子を保持する派生型がオーバーライドします。</remarks>
     public virtual void VisitChildren(Action<RenderObject> visitor) { }
 
 
+    /// <summary>指定した子が必要とする親データを準備します。</summary>
+    /// <param name="child">このRenderObjectへ組み込む子。</param>
+    /// <remarks>親固有の<see cref="IParentData"/>を使用する派生型がオーバーライドします。</remarks>
     public virtual void SetupParentData(RenderObject child) { }
 
 
+    /// <summary>指定した位置を原点として、このRenderObjectを描画コンテキストへ記録します。</summary>
+    /// <param name="context">描画命令と合成レイヤーを記録するコンテキスト。</param>
+    /// <param name="offset">親の座標系における描画原点。</param>
     public abstract void Paint(PaintingContext context, Offset offset);
 
+    /// <summary>描画の再実行を要求します。</summary>
+    /// <remarks>
+    /// すでに描画Dirtyの場合は何もしません。
+    /// 再描画境界では自身を描画Dirtyとしてパイプラインへ登録し、表示更新を要求します。
+    /// 境界でない場合は親方向へ伝播し、最初の再描画境界で登録されます。
+    /// </remarks>
     public void MarkNeedsPaint()
     {
         if (NeedsPaint) return;
@@ -176,8 +272,16 @@ public abstract class RenderObject : IHitTestTarget
         }
     }
 
+    /// <summary>このRenderObjectを描画パイプラインから切り離します。</summary>
+    /// <remarks>接続先を解除します。子を保持する派生型は子にも切り離しを伝播します。</remarks>
     public virtual void Detach() => Owner = null;
 
+    /// <summary>子をこのRenderObjectのレンダーツリーから取り外します。</summary>
+    /// <param name="child">取り外す子。</param>
+    /// <remarks>
+    /// 子の再レイアウト境界、親データ、親への参照を消去し、接続中の場合は子をデタッチします。
+    /// 取り外し後はこのRenderObjectへレイアウトDirtyを要求します。
+    /// </remarks>
     public void DropChild(RenderObject child)
     {
         child.CleanChildRelayoutBoundary();
@@ -193,5 +297,8 @@ public abstract class RenderObject : IHitTestTarget
     }
 
     
+    /// <summary>ヒットテストで選択されたこのRenderObjectへポインターイベントを配信します。</summary>
+    /// <param name="pointerEvent">配信するポインターイベント。</param>
+    /// <param name="entry">ヒットテスト時に生成された、このRenderObjectに対応する結果。</param>
     public abstract void HandleEvent(PointerEvent pointerEvent, HitTestEntry entry);
 }

--- a/src/FloatSoda/Widgets/Key.cs
+++ b/src/FloatSoda/Widgets/Key.cs
@@ -1,10 +1,27 @@
 ﻿namespace FloatSoda.Widgets;
 
+/// <summary>
+/// Widgetツリーの差分更新でウィジェットを識別するキーのマーカーインターフェースです。
+/// </summary>
 public interface IKey;
 
+/// <summary>
+/// 値の等価性によってウィジェットを識別するキーです。
+/// 同じ型引数と等しい値を持つキーは、同じウィジェットを示します。
+/// </summary>
+/// <typeparam name="T">ウィジェットの識別に使用する値の型。</typeparam>
+/// <param name="Value">ウィジェットを識別する値。</param>
 public record struct ValueKey<T>(T Value) : IKey;
 
+/// <summary>
+/// GUIDによってウィジェットを識別するキーです。
+/// 既定の初期化で生成した各インスタンスは、異なるウィジェットを示します。
+/// </summary>
 public record struct UniqueKey() : IKey
 {
+    /// <summary>
+    /// キーの等価性判定に使用する識別子を取得します。
+    /// 値を明示しない場合は、新しいインスタンスの生成時に一意なGUIDが割り当てられます。
+    /// </summary>
     public Guid Id { get; init; } = Guid.NewGuid();
 }

--- a/src/FloatSoda/Widgets/MultiChildRenderObjectWidget.cs
+++ b/src/FloatSoda/Widgets/MultiChildRenderObjectWidget.cs
@@ -3,10 +3,23 @@ using FloatSoda.RenderObjects;
 
 namespace FloatSoda.Widgets;
 
+/// <summary>
+/// 順序を持つ複数の子ウィジェットをRenderObjectへ接続する構成を宣言するウィジェットの基底型です。
+/// </summary>
+/// <typeparam name="T">このウィジェットが構成するRenderObjectの型。</typeparam>
 public abstract record MultiChildRenderObjectWidget<T> : RenderObjectWidget<T> where T : RenderObject
 {
+    /// <summary>
+    /// RenderObjectへ先頭から順に接続する子ウィジェットの一覧を取得します。
+    /// 既定値は空の一覧です。
+    /// </summary>
+    /// <remarks>
+    /// 更新時はウィジェットのランタイム型とキーを使用して既存のElementとの差分が計算され、
+    /// 再利用できない子だけが置き換えられます。
+    /// </remarks>
     public List<Widget> Children { get; init; } = [];
 
+    /// <inheritdoc/>
     public override Element CreateElement()
     {
         return new MultiChildRenderObjectElement<T>

--- a/src/FloatSoda/Widgets/RenderObjectToWidgetAdapter.cs
+++ b/src/FloatSoda/Widgets/RenderObjectToWidgetAdapter.cs
@@ -3,14 +3,48 @@ using FloatSoda.RenderObjects;
 
 namespace FloatSoda.Widgets;
 
+/// <summary>
+/// 既存の<see cref="RenderView"/>をルートとして、WidgetツリーとRenderObjectツリーを接続します。
+/// </summary>
+/// <remarks>
+/// 初回接続ではルートElementをマウントし、再接続では同じElementを再利用して新しい子構成の再ビルドを予約します。
+/// </remarks>
 public record RenderObjectToWidgetAdapter : RenderObjectWidget<RenderView>
 {
+    /// <summary>
+    /// Widgetツリーの描画先となる既存のルートRenderViewを取得します。
+    /// このアダプターは新しいRenderViewを生成せず、指定されたインスタンスを使用します。
+    /// </summary>
     public required RenderView Container { get; init; }
+    /// <summary>
+    /// ルートRenderViewの子として構築するウィジェットを取得します。
+    /// <see langword="null"/>の場合、ルートは子を持ちません。
+    /// </summary>
     public Widget? Child { get; init; }
+    /// <inheritdoc/>
     public override Element CreateElement() => new RenderObjectToWidgetElement<RenderView>();
 
+    /// <summary>
+    /// <see cref="Container"/>で指定された既存のRenderViewを返します。
+    /// </summary>
+    /// <returns>Widgetツリーのルートとして使用するRenderView。</returns>
     public override RenderView CreateRenderObject() => Container;
 
+    /// <summary>
+    /// このアダプターをWidgetツリーのルートへ接続または再接続します。
+    /// </summary>
+    /// <param name="owner">ルートElementの再ビルドを管理するBuildOwner。</param>
+    /// <param name="element">
+    /// 再利用する既存のルートElement。初回接続では<see langword="null"/>を指定します。
+    /// </param>
+    /// <returns>
+    /// 初回接続で生成された、または再接続で再利用されたルートElement。
+    /// </returns>
+    /// <remarks>
+    /// <paramref name="element"/>が<see langword="null"/>の場合は、BuildOwnerのビルドスコープ内で
+    /// 新しいElementをマウントします。既存のElementを指定した場合は、このアダプターを次の構成として保持し、
+    /// Elementを再ビルド対象としてスケジュールします。
+    /// </remarks>
     public RenderObjectToWidgetElement<RenderView> AttachToRenderTree(BuildOwner owner, RenderObjectToWidgetElement<RenderView>? element)
     {
         RenderObjectToWidgetElement<RenderView> result;

--- a/src/FloatSoda/Widgets/RenderObjectWidget.cs
+++ b/src/FloatSoda/Widgets/RenderObjectWidget.cs
@@ -2,9 +2,27 @@
 
 namespace FloatSoda.Widgets;
 
+/// <summary>
+/// RenderObjectの生成と更新に必要な構成を宣言するウィジェットの基底型です。
+/// </summary>
+/// <typeparam name="T">このウィジェットが構成するRenderObjectの型。</typeparam>
 public abstract record RenderObjectWidget<T> : Widget where T : RenderObject
 {
+    /// <summary>
+    /// Elementが初めてマウントされるときに、このウィジェットの構成に対応するRenderObjectを生成します。
+    /// </summary>
+    /// <returns>RenderObjectツリーへ接続する新しいRenderObject。</returns>
     public abstract T CreateRenderObject();
 
+    /// <summary>
+    /// 既存のElementが再利用されたときに、現在のウィジェットの構成をRenderObjectへ反映します。
+    /// </summary>
+    /// <param name="renderObject">
+    /// <see cref="CreateRenderObject"/>によって生成され、Elementが現在保持しているRenderObject。
+    /// </param>
+    /// <remarks>
+    /// 既定の実装は何も変更しません。派生型は、構成値の変更に応じて必要なDirty状態が更新されるよう、
+    /// RenderObjectの公開プロパティを介して差分を反映します。
+    /// </remarks>
     public virtual void UpdateRenderObject(T renderObject) {}
 }

--- a/src/FloatSoda/Widgets/ServiceProvider.cs
+++ b/src/FloatSoda/Widgets/ServiceProvider.cs
@@ -3,29 +3,75 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace FloatSoda.Widgets;
 
+/// <summary>
+/// 子孫のBuildContextへ依存性注入コンテナーを公開するInheritedWidgetです。
+/// </summary>
 public record ServiceProvider : InheritedWidget
 {
+    /// <summary>
+    /// 子孫からサービスを解決するときに使用する依存性注入コンテナーを取得します。
+    /// </summary>
     public required IServiceProvider Services { get; init; }
 
+    /// <summary>
+    /// 最も近い祖先の<see cref="ServiceProvider"/>から依存性注入コンテナーを取得し、
+    /// 呼び出し元をそのInheritedWidgetの依存対象として登録します。
+    /// </summary>
+    /// <param name="context">サービスを要求するウィジェットのBuildContext。</param>
+    /// <returns>最も近い祖先が公開している依存性注入コンテナー。</returns>
+    /// <exception cref="InvalidOperationException">
+    /// 祖先に<see cref="ServiceProvider"/>が存在しない場合にスローされます。
+    /// </exception>
     public static IServiceProvider Of(IBuildContext context)
     {
         return context.DependOnInheritedWidgetOfExactType<ServiceProvider>()?.Services ??
                throw new InvalidOperationException("ServiceScopeが祖先に見つかりません。");
     }
 
+    /// <summary>
+    /// 依存性注入コンテナーの参照が変更され、依存するElementの再ビルドが必要かを判定します。
+    /// </summary>
+    /// <param name="oldWidget">更新前のInheritedWidget。</param>
+    /// <returns>
+    /// 更新前のウィジェットが<see cref="ServiceProvider"/>であり、
+    /// <see cref="Services"/>の参照が変更された場合は<see langword="true"/>。
+    /// それ以外の場合は<see langword="false"/>。
+    /// </returns>
     public override bool UpdateShouldNotify(InheritedWidget oldWidget)
     {
         return oldWidget is ServiceProvider oldScope && !ReferenceEquals(oldScope.Services, Services);
     }
 }
 
+/// <summary>
+/// BuildContextから祖先の依存性注入コンテナーを使用してサービスを解決する拡張メソッドを提供します。
+/// </summary>
 public static class ServiceScopeExtension
 {
+    /// <summary>
+    /// 最も近い祖先の依存性注入コンテナーから、登録必須のサービスを取得します。
+    /// </summary>
+    /// <typeparam name="T">取得するサービスの型。</typeparam>
+    /// <param name="context">サービスを要求するウィジェットのBuildContext。</param>
+    /// <returns>依存性注入コンテナーに登録されているサービス。</returns>
+    /// <exception cref="InvalidOperationException">
+    /// 祖先に<see cref="ServiceProvider"/>が存在しない場合、または要求したサービスが登録されていない場合に
+    /// スローされます。
+    /// </exception>
     public static T GetRequiredService<T>(this IBuildContext context) where T : notnull
     {
         return ServiceProvider.Of(context).GetRequiredService<T>();
     }
 
+    /// <summary>
+    /// 最も近い祖先の依存性注入コンテナーから、登録されている場合にサービスを取得します。
+    /// </summary>
+    /// <typeparam name="T">取得するサービスの型。</typeparam>
+    /// <param name="context">サービスを要求するウィジェットのBuildContext。</param>
+    /// <returns>登録されているサービス。登録されていない場合は<see langword="null"/>。</returns>
+    /// <exception cref="InvalidOperationException">
+    /// 祖先に<see cref="ServiceProvider"/>が存在しない場合にスローされます。
+    /// </exception>
     public static T? GetService<T>(this IBuildContext context)
     {
         return ServiceProvider.Of(context).GetService<T>();

--- a/src/FloatSoda/Widgets/SingleChildRenderObjectWidget.cs
+++ b/src/FloatSoda/Widgets/SingleChildRenderObjectWidget.cs
@@ -3,10 +3,19 @@ using FloatSoda.RenderObjects;
 
 namespace FloatSoda.Widgets;
 
+/// <summary>
+/// 1つの子ウィジェットを持つRenderObjectの構成を宣言するウィジェットの基底型です。
+/// </summary>
+/// <typeparam name="T">このウィジェットが構成するRenderObjectの型。</typeparam>
 public abstract record SingleChildRenderObjectWidget<T> : RenderObjectWidget<T> where T : RenderObject
 {
+    /// <summary>
+    /// RenderObjectの子として接続するウィジェットを取得します。
+    /// <see langword="null"/>の場合、子を持たない構成として扱われます。
+    /// </summary>
     public Widget? Child { get; init; }
 
+    /// <inheritdoc/>
     public override Element CreateElement() => new SingleChildRenderObjectElement<T>
     {
         Widget = this

--- a/src/FloatSoda/Widgets/Widget.cs
+++ b/src/FloatSoda/Widgets/Widget.cs
@@ -2,16 +2,38 @@
 
 namespace FloatSoda.Widgets;
 
+/// <summary>
+/// UI要素の構成を宣言する不変なオブジェクトの基底型です。
+/// Elementツリーの作成と更新に必要な構成情報を保持します。
+/// </summary>
 public abstract record Widget
 {
+    /// <summary>
+    /// Elementツリーの差分更新で、このウィジェットを識別するキーを取得します。
+    /// キーを指定しない場合は、同じ位置にある同一ランタイム型のウィジェットを更新対象として再利用できます。
+    /// </summary>
     public IKey? Key { get; init; }
     
+    /// <summary>
+    /// 既存のElementを維持したまま、古いウィジェットを新しいウィジェットで更新できるかを判定します。
+    /// </summary>
+    /// <param name="oldWidget">既存のElementに現在関連付けられているウィジェット。</param>
+    /// <param name="newWidget">同じ位置へ新たに配置するウィジェット。</param>
+    /// <returns>
+    /// 両方のランタイム型が同一で、かつ<see cref="Key"/>が等しい場合は<see langword="true"/>。
+    /// それ以外の場合は<see langword="false"/>。
+    /// </returns>
     public static bool CanUpdate(Widget oldWidget, Widget newWidget)
     {
         return oldWidget.GetType() == newWidget.GetType() && Equals(oldWidget.Key, newWidget.Key);
     }
 
+    /// <summary>
+    /// このウィジェットの構成をElementツリーへ反映するElementを生成します。
+    /// </summary>
+    /// <returns>このウィジェットに対応する未マウントのElement。</returns>
     public abstract Element CreateElement();
 
+    /// <inheritdoc/>
     public override int GetHashCode() => (Key != null ? Key.GetHashCode() : 0);
 }


### PR DESCRIPTION
## Summary
- `docs/DocumentationComments.md` の規約(日本語限定・Dirtyフラグ副作用明記・`<inheritdoc/>`使用条件・入力語彙統一)に沿って、CS1591警告(ドキュメントコメント欠落)のあったpublicメンバーへXMLドキュメントコメントを追加
- 対象: `FloatSoda.Abstractions`(値型・インターフェース)、`FloatSoda`(Widget/Element/RenderObject基盤)、`FloatSoda.Rendering`(Layers)、`FloatSoda.Engine`
- CS1591警告: ソリューション全体で 1005件 → 20件 に削減(残りはFloatSoda本体の具象クラス群・UI層の一部)
- ロジック・シグネチャの変更なし(コメント追加のみ)
- Codex CLIへの委任(codex-runner、GOAL/SUCCESS CRITERIA形式)+ 人間による独立検証(build/diff/test)で作成

## Test plan
- [x] `dotnet build FloatSoda.slnx` — 0エラー
- [x] `dotnet test tests/FloatSoda.Test` — 187/187件成功
- [x] `dotnet test tests/FloatSoda.Rendering.Test` — 8/8件成功
- [x] 対象ファイルの `git diff` がコメント行の追加のみであることを確認(ロジック変更なし)
- [x] 対象ファイルのCS1591警告が0件であることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)