### PR TITLE
docs: RenderObjects/Widgets具象クラスとCore/Animation/Geometricsのドキュメントコメントを整備

### DIFF
--- a/src/FloatSoda.Engine/OverlayWindow.cs
+++ b/src/FloatSoda.Engine/OverlayWindow.cs
@@ -7,13 +7,25 @@ using FloatSoda.OVR.Overlay;
 
 namespace FloatSoda.Engine;
 
+/// <summary>SteamVRオーバーレイを描画先とする<see cref="IEngineWindow"/>の実装です。</summary>
+/// <seealso cref="IOverlay"/>
 public class OverlayWindow : IEngineWindow
 {
     private readonly Renderer renderer;
     private readonly Dpm dpm;
 
+    /// <summary>このウィンドウが描画先とするOpenVRオーバーレイを取得します。</summary>
     public IOverlay Overlay { get; }
 
+    /// <summary>指定されたオーバーレイを描画先とするウィンドウを作成します。</summary>
+    /// <param name="overlay">描画先となるOpenVRオーバーレイ。</param>
+    /// <param name="renderer">レイヤーツリーをテクスチャへ描画するレンダラー。</param>
+    /// <param name="dpm">ピクセルサイズをオーバーレイの物理幅へ換算する際に使用する密度。</param>
+    /// <remarks>
+    /// <paramref name="overlay"/>がダッシュボードオーバーレイの場合、入力方式をマウスへ設定し、
+    /// SteamVRのレーザーポインター入力を受け取る<see cref="PointerSource"/>を生成します。
+    /// それ以外のオーバーレイでは<see cref="PointerSource"/>は<see langword="null"/>のままです。
+    /// </remarks>
     public OverlayWindow(IOverlay overlay, Renderer renderer, Dpm dpm)
     {
         Overlay = overlay;
@@ -30,6 +42,11 @@ public class OverlayWindow : IEngineWindow
         }
     }
 
+    /// <summary>
+    /// 指定されたレイヤーツリーを描画し、結果のテクスチャをオーバーレイへ反映します。
+    /// </summary>
+    /// <param name="layer">描画するレイヤーツリー。<see langword="null"/>は指定できません。</param>
+    /// <remarks>レンダースレッド上で呼び出します。</remarks>
     public void Present(ILayer layer)
     {
         renderer.Render(layer);
@@ -60,6 +77,8 @@ public class OverlayWindow : IEngineWindow
         }
     }
 
+    /// <summary>このウィンドウの生ポインター入力源を取得します。</summary>
+    /// <value>ダッシュボードオーバーレイの場合はレーザーポインター入力源。それ以外では<see langword="null"/>です。</value>
     public IRawPointerSource? PointerSource { get; }
 
     /// <summary>
@@ -73,6 +92,7 @@ public class OverlayWindow : IEngineWindow
         Overlay.EventDispatcher.PollEvents();
     }
 
+    /// <summary>このウィンドウの生ポインター入力源とオーバーレイを破棄します。</summary>
     public void Dispose()
     {
         PointerSource?.Dispose();

--- a/src/FloatSoda/Animation/AnimationController.cs
+++ b/src/FloatSoda/Animation/AnimationController.cs
@@ -3,9 +3,13 @@ namespace FloatSoda.Animation;
 /// <summary>値が完了・初期状態のどちら側にあるか、どちらへ進行中かを表します。</summary>
 public enum AnimationStatus
 {
+    /// <summary>値が下限にあり、停止している状態です。</summary>
     Dismissed, // 停止・先頭(LowerBound)
+    /// <summary>値が上限へ向かって進行している状態です。</summary>
     Forward, // 順方向に進行中
+    /// <summary>値が下限へ向かって進行している状態です。</summary>
     Reverse, // 逆方向に進行中
+    /// <summary>値が上限にあり、停止している状態です。</summary>
     Completed, // 停止・末尾(UpperBound)
 }
 
@@ -19,13 +23,19 @@ public interface IListenable
 /// <summary>時間経過で変化する値。FlutterのAnimation&lt;T&gt;相当。</summary>
 public interface IAnimation<out T> : IListenable
 {
+    /// <summary>現在のアニメーション値を取得します。</summary>
     T Value { get; }
+    /// <summary>現在の進行状態を取得します。</summary>
     AnimationStatus Status { get; }
 
     /// <summary>Statusが遷移したときに新しい値を伴って発火します。</summary>
     event Action<AnimationStatus>? StatusChanged;
 }
 
+/// <summary>指定された範囲の値をフレーム単位で更新するアニメーションを制御します。</summary>
+/// <remarks>再生中は<see cref="Vsync"/>からフレーム通知を受け、値または状態が変化した場合に通知を発行します。</remarks>
+/// <seealso cref="IAnimation{T}"/>
+/// <seealso cref="ISimulation"/>
 public class AnimationController : IAnimation<double>, IDisposable
 {
     /// <summary>tickの供給元。通常はState側のITickerProvider実装を渡します。</summary>
@@ -34,8 +44,11 @@ public class AnimationController : IAnimation<double>, IDisposable
     /// <summary>Forward/Reverseの標準所要時間。</summary>
     public required TimeSpan Duration { get; init; }
 
+    /// <summary>アニメーション値の下限を取得します。既定値は0です。</summary>
     public double LowerBound { get; init; } = 0.0;
+    /// <summary>アニメーション値の上限を取得します。既定値は1です。</summary>
     public double UpperBound { get; init; } = 1.0;
+    /// <summary>範囲内の進行率へ適用する曲線を取得します。既定では線形に補間します。</summary>
     public ICurve Curve { get; init; } = new LinearCurve(); // Curveに静的プロパティを足す想定
 
     private WidgetTicker? _ticker;
@@ -46,10 +59,14 @@ public class AnimationController : IAnimation<double>, IDisposable
 
     private double? _value;
 
+    /// <inheritdoc />
     public double Value => _value ?? LowerBound;
+    /// <inheritdoc />
     public AnimationStatus Status { get; private set; } = AnimationStatus.Dismissed;
 
+    /// <inheritdoc />
     public event Action? Changed;
+    /// <inheritdoc />
     public event Action<AnimationStatus>? StatusChanged;
 
     /// <summary>UpperBoundへ向けて再生します。fromを指定するとその値から開始します。</summary>
@@ -149,6 +166,7 @@ public class AnimationController : IAnimation<double>, IDisposable
         _ticker?.Stop();
     }
 
+    /// <summary>フレーム通知を停止し、このコントローラーが保持する通知先を解放します。</summary>
     public void Dispose()
     {
         _ticker?.Dispose();

--- a/src/FloatSoda/Animation/Simulation.cs
+++ b/src/FloatSoda/Animation/Simulation.cs
@@ -1,20 +1,37 @@
 ﻿namespace FloatSoda.Animation;
 
+/// <summary>経過時間に応じた値と速度を算出するアニメーションシミュレーションを表します。</summary>
 public interface ISimulation
 {
     // TODO:  あまりにも単純すぎる名前なので適切な命名を考える
+    /// <summary>指定時刻における値を取得します。</summary>
+    /// <param name="time">シミュレーション開始からの経過秒数。</param>
+    /// <returns>指定時刻における値。</returns>
     double X(double time);
 
     // TODO: あまりにも単純すぎる名前なので適切な命名を考える
+    /// <summary>指定時刻における1秒あたりの値の変化量を取得します。</summary>
+    /// <param name="time">シミュレーション開始からの経過秒数。</param>
+    /// <returns>指定時刻における1秒あたりの値の変化量。</returns>
     double Dx(double time);
+    /// <summary>指定時刻でシミュレーションが完了しているかを判定します。</summary>
+    /// <param name="time">シミュレーション開始からの経過秒数。</param>
+    /// <returns>完了している場合は<see langword="true"/>、継続中の場合は<see langword="false"/>。</returns>
     bool IsDone(double time);
 }
 
+/// <summary>開始値から終了値までを指定された曲線で補間するシミュレーションです。</summary>
+/// <param name="begin">開始時の値。</param>
+/// <param name="end">完了時の値。</param>
+/// <param name="duration">補間に要する時間。</param>
+/// <param name="curve">正規化された進行率へ適用する曲線。</param>
+/// <seealso cref="AnimationController"/>
 public class InterpolationSimulation(double begin, double end, TimeSpan duration, ICurve curve) : ISimulation
 {
     private readonly double _durationInSeconds = duration.TotalSeconds;
 
 
+    /// <inheritdoc />
     public double X(double time)
     {
         var t = Math.Clamp(time / _durationInSeconds, 0, 1);
@@ -28,11 +45,13 @@ public class InterpolationSimulation(double begin, double end, TimeSpan duration
     }
 
 
+    /// <inheritdoc />
     public double Dx(double time)
     {
         const double epsilon = 1e-4;
         return (X(time + epsilon) - X(time - epsilon)) / (2 * epsilon);
     }
 
+    /// <inheritdoc />
     public bool IsDone(double time) => time > _durationInSeconds;
 }

--- a/src/FloatSoda/Animation/Ticker.cs
+++ b/src/FloatSoda/Animation/Ticker.cs
@@ -93,6 +93,7 @@ public class WidgetTicker(
     /// <summary>次フレームのコールバックが登録済みかどうか。</summary>
     public bool Scheduled => _animationId != null;
 
+    /// <summary>フレームコールバックを解除し、生成元による追跡からこのTickerを取り除きます。</summary>
     public void Dispose()
     {
         creator.RemoveTicker(this);
@@ -104,7 +105,12 @@ public class WidgetTicker(
 /// <summary>Tickerの供給元。FlutterのTickerProvider相当。</summary>
 public interface ITickerProvider
 {
+    /// <summary>指定された処理へフレームごとの経過時間を通知するTickerを作成します。</summary>
+    /// <param name="onTick">フレームごとに呼び出す処理。引数はTicker開始からの経過時間です。</param>
+    /// <returns>この供給元が追跡するTicker。</returns>
     WidgetTicker CreateTicker(Action<TimeSpan> onTick);
+    /// <summary>指定されたTickerを供給元の追跡対象から取り除きます。</summary>
+    /// <param name="ticker">追跡を終了するTicker。</param>
     void RemoveTicker(WidgetTicker ticker);
 }
 
@@ -122,6 +128,7 @@ public class TickerProvider : ITickerProvider
 
     private readonly HashSet<WidgetTicker> _tickers = [];
 
+    /// <inheritdoc />
     public WidgetTicker CreateTicker(Action<TimeSpan> onTick)
     {
         var result = new WidgetTicker(onTick, this, ResolveScheduler);
@@ -131,5 +138,6 @@ public class TickerProvider : ITickerProvider
         return result;
     }
 
+    /// <inheritdoc />
     public void RemoveTicker(WidgetTicker ticker) => _tickers.Remove(ticker);
 }

--- a/src/FloatSoda/Animation/TickerProviderState.cs
+++ b/src/FloatSoda/Animation/TickerProviderState.cs
@@ -20,7 +20,9 @@ public abstract class TickerProviderState<T> : State<T>, ITickerProvider
         ResolveScheduler = () => Element?.Owner?.FrameScheduler
     };
 
+    /// <inheritdoc />
     public WidgetTicker CreateTicker(Action<TimeSpan> onTick) => TickerProvider.CreateTicker(onTick);
 
+    /// <inheritdoc />
     public void RemoveTicker(WidgetTicker ticker) => TickerProvider.RemoveTicker(ticker);
 }

--- a/src/FloatSoda/Core/HotReloadHandler.cs
+++ b/src/FloatSoda/Core/HotReloadHandler.cs
@@ -12,12 +12,18 @@ namespace FloatSoda.Core;
 /// </summary>
 public static class HotReloadHandler
 {
+    /// <summary>更新された型に関連するキャッシュを破棄します。</summary>
+    /// <param name="updatedTypes">更新された型の配列。更新対象を特定できない場合は<see langword="null"/>です。</param>
+    /// <remarks>現在は破棄対象のキャッシュを持たず、呼び出しをコンソールへ記録します。</remarks>
     public static void ClearCache(Type[]? updatedTypes)
     {
         // 現状破棄すべきキャッシュはない（ImageProvider等のキャッシュ導入時にここへ接続する）
         Console.WriteLine("[🥤FloatSoda HotReload] 🗑️ ClearCache");
     }
 
+    /// <summary>コード更新を稼働中のアプリケーションへ通知します。</summary>
+    /// <param name="updatedTypes">更新された型の配列。更新対象を特定できない場合は<see langword="null"/>です。</param>
+    /// <remarks>稼働中の各アプリケーションへ再構築を予約し、実際のWidgetツリー再構築は各メインループの次フレームで行われます。</remarks>
     public static void UpdateApplication(Type[]? updatedTypes)
     {
         Console.WriteLine("[🥤FloatSoda HotReload] 🔥 コード差し替えを検知、Widgetツリーを再ビルドします");

--- a/src/FloatSoda/Core/ImageProvider.cs
+++ b/src/FloatSoda/Core/ImageProvider.cs
@@ -3,13 +3,21 @@ using SkiaSharp;
 
 namespace FloatSoda.Core;
 
+/// <summary>描画に使用する画像を読み込む方法を表します。</summary>
+/// <seealso cref="FileImageProvider"/>
 public abstract record ImageProvider
 {
+    /// <summary>画像データを読み込みます。</summary>
+    /// <returns>呼び出し元が破棄する画像オブジェクト。</returns>
     public abstract SKImage Load();
 }
 
+/// <summary>ファイルから画像データを読み込むプロバイダーです。</summary>
+/// <param name="Path">読み込む画像ファイルのパス。</param>
+/// <seealso cref="ImageProvider"/>
 public record FileImageProvider(string Path) : ImageProvider
 {
+    /// <inheritdoc />
     public override SKImage Load()
     {
         IHost host;

--- a/src/FloatSoda/Core/RenderPipeline.cs
+++ b/src/FloatSoda/Core/RenderPipeline.cs
@@ -2,10 +2,17 @@
 
 namespace FloatSoda.Core;
 
+/// <summary>RenderObjectツリーの未処理レイアウトと未処理描画をフレーム単位で実行します。</summary>
+/// <remarks>Dirty状態のRenderObjectを深さ順に処理し、現在このパイプラインに所属するノードだけを更新します。</remarks>
+/// <seealso cref="RenderView"/>
 public class RenderPipeline
 {
+    /// <summary>次フレームで視覚更新が必要になったときに呼び出す処理を取得します。</summary>
+    /// <remarks>Dirtyリストが空の状態から更新が予約された際に、フレーム処理を起動するために使用します。</remarks>
     public required Action OnNeedVisualUpdate { get; init; }
 
+    /// <summary>このパイプラインが管理するRenderObjectツリーのルートを取得または設定します。</summary>
+    /// <remarks>設定したルートは直ちにこのパイプラインへ接続されます。</remarks>
     public required RenderView RenderView
     {
         get;
@@ -16,9 +23,15 @@ public class RenderPipeline
         }
     }
 
+    /// <summary>次回の描画フラッシュを待つRenderObjectの一覧を取得します。</summary>
+    /// <remarks>描画フラッシュ開始時に一覧は消去され、処理中に新たにDirtyとなったノードは次回の描画対象になります。</remarks>
     public List<RenderObject> NodesNeedingPaint { get; } = [];
+    /// <summary>次回のレイアウトフラッシュを待つRenderObjectの一覧を取得します。</summary>
+    /// <remarks>レイアウト中に新たなDirtyノードが登録された場合は、一覧が空になるまで同じフラッシュ内で処理します。</remarks>
     public List<RenderObject> NodesNeedingLayout { get; } = [];
 
+    /// <summary>レイアウトがDirtyなノードを祖先から子孫の順に再レイアウトします。</summary>
+    /// <remarks>処理によって追加されたDirtyノードも、待機一覧が空になるまで同じ呼び出し内で処理します。</remarks>
     public void FlushLayout()
     {
         while (NodesNeedingLayout.Count != 0)
@@ -37,6 +50,8 @@ public class RenderPipeline
         }
     }
 
+    /// <summary>描画がDirtyなノードを祖先から子孫の順に再描画します。</summary>
+    /// <remarks>開始時点の待機一覧を消去して処理するため、処理中に追加されたDirtyノードは次回の描画フラッシュで処理されます。</remarks>
     public void FlushPaint()
     {
         var dirtyNodes = NodesNeedingPaint.OrderBy(x => x.Depth).ToList();
@@ -52,5 +67,7 @@ public class RenderPipeline
         }
     }
 
+    /// <summary>視覚更新が必要であることをフレーム管理側へ通知します。</summary>
+    /// <remarks>この呼び出し自体はレイアウトや描画を実行せず、次フレームの更新を予約します。</remarks>
     public void RequestVisualUpdate() => OnNeedVisualUpdate();
 }

--- a/src/FloatSoda/Core/ViewConfiguration.cs
+++ b/src/FloatSoda/Core/ViewConfiguration.cs
@@ -2,4 +2,6 @@
 
 namespace FloatSoda.Core;
 
+/// <summary>描画対象ビューのピクセル単位の大きさを表す不変の構成値です。</summary>
+/// <param name="Size">ビューの幅と高さ。単位はピクセルです。</param>
 public readonly record struct ViewConfiguration(SKSize Size);

--- a/src/FloatSoda/Core/WidgetBinding.cs
+++ b/src/FloatSoda/Core/WidgetBinding.cs
@@ -14,8 +14,13 @@ using OverlayWindow = FloatSoda.Engine.OverlayWindow;
 
 namespace FloatSoda.Core;
 
+/// <summary>1つのウィンドウについてWidgetの再構築、レイアウト、描画、入力処理をフレーム単位で調整します。</summary>
+/// <remarks>再構築またはRenderObjectのDirty通知で視覚更新を予約し、次のフレームで必要な処理だけを実行します。</remarks>
+/// <seealso cref="RenderPipeline"/>
+/// <seealso cref="BuildOwner"/>
 public class WidgetBinding : IFrameScheduler, IHitTestTarget, IGestureBinding
 {
+    /// <summary>フレーム予約とジェスチャ処理をこのウィンドウへ関連付けたバインディングを初期化します。</summary>
     public WidgetBinding()
     {
         BuildOwner = new BuildOwner(EnsureVisualUpdate) { FrameScheduler = this, GestureBinding = this };
@@ -29,19 +34,29 @@ public class WidgetBinding : IFrameScheduler, IHitTestTarget, IGestureBinding
 
     private RenderPipeline? Pipeline { get; set; }
     private BuildOwner BuildOwner { get; set; }
+    /// <summary>ウィンドウのWidgetツリーをRenderViewへ接続するルートElementを取得します。</summary>
+    /// <value>ルートWidgetが接続される前は<see langword="null"/>です。</value>
     public Element? RenderViewElement { get; private set; }
     private RenderThreadRunner? RenderThreadRunner { get; set; }
     private IEngineWindow? Window { get; set; }
+    /// <summary>描画ウィンドウとパイプラインの初期化が開始済みかを取得します。</summary>
     public bool Initialized { get; private set; }
+    /// <summary>次のフレームでレイアウトまたは描画を処理する必要があるかを取得します。</summary>
+    /// <remarks><see cref="EnsureVisualUpdate"/>で設定され、<see cref="DrawFrame"/>が更新処理を開始すると解除されます。</remarks>
     public bool NeedsVisualUpdate { get; private set; }
 
+    /// <summary>このバインディングが管理するウィンドウ名を取得します。</summary>
+    /// <value>初期化前は<see langword="null"/>です。</value>
     public string? WindowName { get; private set; }
 
+    /// <summary>直近のレイアウトで確定したウィンドウのピクセル単位の大きさを取得します。</summary>
+    /// <value>パイプラインの初期化前は空のサイズです。</value>
     public SKSizeI Size => Pipeline?.RenderView.Size.ToSizeI() ?? SKSizeI.Empty;
 
     /// <summary>直近でレンダースレッドへ通知したオーバーレイサイズ。変化検知に使用する。</summary>
     private SKSizeI _lastPostedSize = SKSizeI.Empty;
 
+    /// <summary>直近に発行したフレームコールバック識別子を取得します。初期値は0です。</summary>
     public int NextFrameCallbackId { get; private set; } = 0;
 
     private readonly Dictionary<int, Action<TimeSpan>> _transientCallbacks = [];
@@ -52,6 +67,12 @@ public class WidgetBinding : IFrameScheduler, IHitTestTarget, IGestureBinding
 
     private bool _hasScheduledFrame;
 
+    /// <summary>このバインディングの描画パイプラインとエンジンウィンドウを初回だけ初期化します。</summary>
+    /// <param name="windowName">作成するウィンドウの識別名。</param>
+    /// <param name="renderThreadRunner">ウィンドウ作成と描画処理を実行するレンダースレッド。</param>
+    /// <param name="windowFactory">初期化済みレンダラーからエンジンウィンドウを作成する処理。</param>
+    /// <param name="visible">デスクトップウィンドウを作成時から表示する場合は<see langword="true"/>。既定値は<see langword="false"/>です。</param>
+    /// <remarks>エンジンウィンドウの作成はレンダースレッドへ予約されるため、このメソッドから戻った時点では完了していない場合があります。</remarks>
     public void EnsureInitialized(string windowName, RenderThreadRunner renderThreadRunner,
         Func<Renderer, IEngineWindow> windowFactory, bool visible = false)
     {
@@ -82,6 +103,8 @@ public class WidgetBinding : IFrameScheduler, IHitTestTarget, IGestureBinding
         Pipeline.RenderView.PrepareInitialFrame();
     }
 
+    /// <summary>次のフレームで視覚更新が必要であることを記録します。</summary>
+    /// <remarks>DirtyなElementまたはRenderObjectから呼び出され、<see cref="DrawFrame"/>による再構築、レイアウト、描画の実行を予約します。</remarks>
     public void EnsureVisualUpdate() => NeedsVisualUpdate = true;
 
     /// <summary>
@@ -98,6 +121,9 @@ public class WidgetBinding : IFrameScheduler, IHitTestTarget, IGestureBinding
         RenderThreadRunner?.PostTask(transform.Apply);
     }
 
+    /// <summary>指定されたWidgetをこのウィンドウのRenderViewへルートとして接続します。</summary>
+    /// <param name="rootWidget">接続または更新するルートWidget。</param>
+    /// <remarks>初回接続では視覚更新を予約します。接続済みの場合は既存Elementを再利用して更新します。</remarks>
     public void AttachRootWidget(Widget rootWidget)
     {
         var isBootStrapFrame = RenderViewElement == null;
@@ -121,6 +147,8 @@ public class WidgetBinding : IFrameScheduler, IHitTestTarget, IGestureBinding
     /// </summary>
     public void Reassemble() => RenderViewElement?.Reassemble();
 
+    /// <summary>予約済みのWidget再構築と視覚更新を処理し、完成したレイヤーをレンダースレッドへ送ります。</summary>
+    /// <remarks>Elementの再構築は毎フレーム確認します。<see cref="NeedsVisualUpdate"/>が未設定の場合、またはウィンドウ作成前の場合はレイアウトと描画を行いません。</remarks>
     public void DrawFrame()
     {
         if (RenderViewElement != null)
@@ -159,6 +187,9 @@ public class WidgetBinding : IFrameScheduler, IHitTestTarget, IGestureBinding
         RenderThreadRunner?.PostTask(() => window.Resize(newSize));
     }
 
+    /// <summary>1フレーム分の入力、コールバック、および描画処理を実行します。</summary>
+    /// <param name="elapsedTime">アプリケーション開始からの単調な経過時間。</param>
+    /// <remarks>未初期化の場合は何も行いません。登録済みの一時コールバックはこのフレームで一度だけ実行されます。</remarks>
     public void BeginFrame(TimeSpan elapsedTime)
     {
         if (!Initialized) return;
@@ -175,6 +206,7 @@ public class WidgetBinding : IFrameScheduler, IHitTestTarget, IGestureBinding
         DrawFrame();
     }
 
+    /// <inheritdoc />
     public int ScheduleFrameCallback(Action<TimeSpan> callback)
     {
         ScheduleFrame();
@@ -186,8 +218,11 @@ public class WidgetBinding : IFrameScheduler, IHitTestTarget, IGestureBinding
         return NextFrameCallbackId;
     }
 
+    /// <inheritdoc />
     public void CancelFrameCallback(int id) => _transientCallbacks.Remove(id);
 
+    /// <summary>次のフレーム処理が必要であることを記録します。</summary>
+    /// <remarks>同一フレーム内で複数回呼び出しても予約状態は1件にまとめられ、<see cref="BeginFrame"/>の開始時に解除されます。</remarks>
     public void ScheduleFrame()
     {
         if (_hasScheduledFrame) return;

--- a/src/FloatSoda/Elements/WindowElement.cs
+++ b/src/FloatSoda/Elements/WindowElement.cs
@@ -9,12 +9,14 @@ namespace FloatSoda.Elements;
 /// </summary>
 public class WindowElement : InheritedElement
 {
+    /// <inheritdoc />
     public override void Mount(Element? parent)
     {
         base.Mount(parent);
         ApplySizeToRenderView();
     }
 
+    /// <inheritdoc />
     public override void Update(Widget newWidget)
     {
         base.Update(newWidget);

--- a/src/FloatSoda/FloatSodaApp.cs
+++ b/src/FloatSoda/FloatSodaApp.cs
@@ -15,6 +15,9 @@ using EngineDesktopWindow = FloatSoda.Engine.DesktopWindow;
 
 namespace FloatSoda;
 
+/// <summary>OpenVRのイベント処理と各ウィンドウのフレーム処理を実行するFloatSodaアプリケーションです。</summary>
+/// <remarks>作成したウィンドウはメインループで初期化され、描画処理は専用のレンダースレッドへ送られます。</remarks>
+/// <seealso cref="WidgetBinding"/>
 public class FloatSodaApp : IDisposable
 {
     private readonly RenderThreadRunner _renderThreadRunner;
@@ -113,6 +116,8 @@ public class FloatSodaApp : IDisposable
     }
 
 
+    /// <summary>アプリケーションを初期化し、停止要求を受けるまでメインループを実行します。</summary>
+    /// <remarks>メインループ終了時には、このインスタンスが保持するOpenVRおよびレンダースレッドのリソースを解放します。</remarks>
     [STAThread]
     public void Run()
         => Run(CancellationToken.None, static () => { });
@@ -274,6 +279,7 @@ public class FloatSodaApp : IDisposable
         }
     }
 
+    /// <summary>メインループへ停止を要求し、レンダースレッドとOpenVRリソースを解放します。</summary>
     public void Dispose()
     {
         Dispose(true);

--- a/src/FloatSoda/Geometrics/Alignment.cs
+++ b/src/FloatSoda/Geometrics/Alignment.cs
@@ -3,18 +3,34 @@ using SkiaSharp;
 
 namespace FloatSoda.Geometrics;
 
+/// <summary>矩形内の位置を中心からの正規化された相対座標で表す不変値です。</summary>
+/// <param name="X">水平方向の相対位置。-1は左端、0は中央、1は右端です。既定値は0です。</param>
+/// <param name="Y">垂直方向の相対位置。-1は上端、0は中央、1は下端です。既定値は0です。</param>
+/// <seealso cref="Offset"/>
 public readonly record struct Alignment(float X = 0, float Y = 0)
 {
+    /// <summary>左上を表す配置値を取得します。</summary>
     public static readonly Alignment TopLeft = new(-1, -1);
+    /// <summary>上端中央を表す配置値を取得します。</summary>
     public static readonly Alignment TopCenter = new(0, -1);
+    /// <summary>右上を表す配置値を取得します。</summary>
     public static readonly Alignment TopRight = new(1, -1);
+    /// <summary>左端中央を表す配置値を取得します。</summary>
     public static readonly Alignment CenterLeft = new(-1, 0);
+    /// <summary>中央を表す配置値を取得します。</summary>
     public static readonly Alignment Center = default;
+    /// <summary>右端中央を表す配置値を取得します。</summary>
     public static readonly Alignment CenterRight = new(1, 0);
+    /// <summary>左下を表す配置値を取得します。</summary>
     public static readonly Alignment BottomLeft = new(-1, 1);
+    /// <summary>下端中央を表す配置値を取得します。</summary>
     public static readonly Alignment BottomCenter = new(0, 1);
+    /// <summary>右下を表す配置値を取得します。</summary>
     public static readonly Alignment BottomRight = new(1, 1);
 
+    /// <summary>指定された矩形サイズの中心を原点として、この配置が示す位置を算出します。</summary>
+    /// <param name="size">基準とする矩形の大きさ。単位は論理ピクセルです。</param>
+    /// <returns>矩形中心から配置位置までの論理ピクセル単位のオフセット。</returns>
     public Offset Pivot(SKSize size)
     {
         var centerX = size.Width / 2f;
@@ -26,6 +42,10 @@ public readonly record struct Alignment(float X = 0, float Y = 0)
         return new Offset(offsetX, offsetY);
     }
 
+    /// <summary>親矩形内で子矩形をこの配置に置くための左上座標を算出します。</summary>
+    /// <param name="parent">親矩形の大きさ。単位は論理ピクセルです。</param>
+    /// <param name="child">子矩形の大きさ。単位は論理ピクセルです。</param>
+    /// <returns>親矩形の左上を原点とする、子矩形左上の論理ピクセル単位のオフセット。</returns>
     public Offset ComputeOffset(SKSize parent, SKSize child)
     {
         var remainingSpace = new SKSize(parent.Width - child.Width, parent.Height - child.Height);
@@ -33,7 +53,13 @@ public readonly record struct Alignment(float X = 0, float Y = 0)
         return centerSpace + Pivot(remainingSpace);
     }
 
+    /// <summary>水平および垂直方向を中央に対して反転した配置値を返します。</summary>
+    /// <returns>両成分の符号を反転した新しい配置値。</returns>
     public Alignment FlipAll() => new(-X, -Y);
+    /// <summary>水平方向を中央に対して反転した配置値を返します。</summary>
+    /// <returns>水平成分の符号だけを反転した新しい配置値。</returns>
     public Alignment FlipX() => this with { X = -X };
+    /// <summary>垂直方向を中央に対して反転した配置値を返します。</summary>
+    /// <returns>垂直成分の符号だけを反転した新しい配置値。</returns>
     public Alignment FlipY() => this with { Y = -Y };
 }

--- a/src/FloatSoda/Geometrics/Axis.cs
+++ b/src/FloatSoda/Geometrics/Axis.cs
@@ -1,13 +1,21 @@
 ﻿namespace FloatSoda.Geometrics;
 
+/// <summary>レイアウトの主方向となる軸を表します。</summary>
 public enum Axis
 {
+    /// <summary>左から右へ延びる水平軸です。</summary>
     Horizontal,
+    /// <summary>上から下へ延びる垂直軸です。</summary>
     Vertical
 }
 
+/// <summary><see cref="Axis"/>に関する判定と変換を提供します。</summary>
 public static class AxisExtension
 {
+    /// <summary>水平軸と垂直軸を入れ替えます。</summary>
+    /// <param name="axis">入れ替える軸。</param>
+    /// <returns>水平軸の場合は垂直軸、垂直軸の場合は水平軸。</returns>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="axis"/>が定義済みの値ではありません。</exception>
     public static Axis Flip(this Axis axis) => axis switch
     {
         Axis.Horizontal => Axis.Vertical,
@@ -15,6 +23,11 @@ public static class AxisExtension
         _ => throw new ArgumentOutOfRangeException(nameof(axis), axis, null)
     };
 
+    /// <summary>指定された軸の開始側が上端または左端に当たるかを判定します。</summary>
+    /// <param name="direction">判定する軸。</param>
+    /// <param name="verticalDirection">垂直軸の進行方向。水平軸では結果に影響しません。</param>
+    /// <returns>開始側が左端または上端の場合は<see langword="true"/>、下端の場合は<see langword="false"/>。</returns>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="direction"/>または<paramref name="verticalDirection"/>が定義済みの値ではありません。</exception>
     public static bool StartIsTopLeft(this Axis direction, VerticalDirection verticalDirection)
     {
         return (direction) switch
@@ -31,33 +44,52 @@ public static class AxisExtension
     }
 }
 
+/// <summary>主軸上で子要素を配置する方法を表します。</summary>
 public enum MainAxisAlignment
 {
+    /// <summary>子要素を主軸の開始側へ寄せます。</summary>
     Start,
+    /// <summary>子要素を主軸の終了側へ寄せます。</summary>
     End,
+    /// <summary>子要素を主軸の中央へ寄せます。</summary>
     Center,
+    /// <summary>先頭と末尾を両端へ置き、子要素間に均等な空きを配置します。</summary>
     SpaceBetween,
+    /// <summary>各子要素の前後に均等な空きを配置し、両端の空きを要素間の半分にします。</summary>
     SpaceAround,
+    /// <summary>両端を含むすべての空きを均等に配置します。</summary>
     SpaceEvenly,
 }
 
+/// <summary>交差軸上で子要素を配置する方法を表します。</summary>
 public enum CrossAxisAlignment
 {
+    /// <summary>子要素を交差軸の開始側へ寄せます。</summary>
     Start,
+    /// <summary>子要素を交差軸の終了側へ寄せます。</summary>
     End,
+    /// <summary>子要素を交差軸の中央へ寄せます。</summary>
     Center,
+    /// <summary>子要素を交差軸の利用可能な大きさまで広げます。</summary>
     Stretch,
+    /// <summary>子要素の文字基準線をそろえます。</summary>
     Baseline,
 }
 
+/// <summary>主軸方向にレイアウトが占める大きさを表します。</summary>
 public enum MainAxisSize
 {
+    /// <summary>子要素を収めるために必要な最小の大きさを使用します。</summary>
     Min,
+    /// <summary>主軸方向に利用可能な最大の大きさを使用します。</summary>
     Max,
 }
 
+/// <summary>垂直軸の進行方向を表します。</summary>
 public enum VerticalDirection
 {
+    /// <summary>下端から上端へ進みます。</summary>
     Up,
+    /// <summary>上端から下端へ進みます。</summary>
     Down,
 }

--- a/src/FloatSoda/Geometrics/BorderRadius.cs
+++ b/src/FloatSoda/Geometrics/BorderRadius.cs
@@ -2,18 +2,34 @@
 
 namespace FloatSoda.Geometrics;
 
+/// <summary>矩形の四隅に適用する角丸半径を表す不変値です。</summary>
+/// <param name="TopLeft">左上隅の水平半径と垂直半径。既定値は0です。</param>
+/// <param name="TopRight">右上隅の水平半径と垂直半径。既定値は0です。</param>
+/// <param name="BottomRight">右下隅の水平半径と垂直半径。既定値は0です。</param>
+/// <param name="BottomLeft">左下隅の水平半径と垂直半径。既定値は0です。</param>
+/// <seealso cref="Radius"/>
 public readonly record struct BorderRadius(
     Radius TopLeft = default,
     Radius TopRight = default,
     Radius BottomRight = default,
     Radius BottomLeft = default)
 {
+    /// <summary>四隅へ同じ角丸半径を設定した値を作成します。</summary>
+    /// <param name="radius">四隅へ適用する半径。</param>
+    /// <returns>四隅が同じ半径の新しい値。</returns>
     public static BorderRadius All(Radius radius) => new(radius, radius, radius, radius);
+    /// <summary>すべての半径が0の角丸値を取得します。</summary>
     public static readonly BorderRadius Zero = All(Radius.Zero);
 
+    /// <summary>四隅へ同じ円形半径を設定した値を作成します。</summary>
+    /// <param name="radius">水平および垂直方向へ適用する論理ピクセル単位の半径。</param>
+    /// <returns>四隅が同じ円形半径の新しい値。</returns>
     public static BorderRadius Circular(float radius) => All(Radius.Circular(radius));
 
 
+    /// <summary>指定された矩形へこの角丸半径を適用した描画用矩形を作成します。</summary>
+    /// <param name="rect">角丸を適用する矩形。半径と同じ座標単位を使用します。</param>
+    /// <returns>各隅に対応する半径を持つ新しい描画用矩形。</returns>
     public SKRoundRect ToRoundRect(SKRect rect)
     {
         var roundRect = new SKRoundRect(rect);
@@ -24,9 +40,20 @@ public readonly record struct BorderRadius(
     }
 }
 
+/// <summary>角丸の水平半径と垂直半径を表す値です。</summary>
+/// <param name="X">水平方向の半径。単位は論理ピクセルで、既定値は0です。</param>
+/// <param name="Y">垂直方向の半径。単位は論理ピクセルで、既定値は0です。</param>
+/// <seealso cref="BorderRadius"/>
 public record struct Radius(float X = 0, float Y = 0)
 {
+    /// <summary>水平半径と垂直半径が等しい円形半径を作成します。</summary>
+    /// <param name="radius">両方向へ適用する論理ピクセル単位の半径。</param>
+    /// <returns>両方向が等しい新しい半径。</returns>
     public static Radius Circular(float radius) => new(radius, radius);
+    /// <summary>水平半径と垂直半径が0の値を取得します。</summary>
     public static readonly Radius Zero = new(0, 0);
+    /// <summary>半径を同じ成分を持つ描画用座標へ変換します。</summary>
+    /// <param name="radius">変換する半径。</param>
+    /// <returns>水平半径をX、垂直半径をYに保持する座標。</returns>
     public static implicit operator SKPoint(Radius radius) => new(radius.X, radius.Y);
 }

--- a/src/FloatSoda/Geometrics/BoxConstraints.cs
+++ b/src/FloatSoda/Geometrics/BoxConstraints.cs
@@ -4,6 +4,12 @@ namespace FloatSoda.Geometrics;
 
 using static Double;
 
+/// <summary>レイアウトで許容する幅と高さの範囲を論理ピクセル単位で表す不変値です。</summary>
+/// <param name="MinWidth">許容する最小幅。既定値は0です。</param>
+/// <param name="MaxWidth">許容する最大幅。既定値は正の無限大です。</param>
+/// <param name="MinHeight">許容する最小高さ。既定値は0です。</param>
+/// <param name="MaxHeight">許容する最大高さ。既定値は正の無限大です。</param>
+/// <seealso cref="FloatSoda.RenderObjects.RenderBox"/>
 public readonly record struct BoxConstraints(
     double MinWidth = 0,
     double MaxWidth = PositiveInfinity,
@@ -16,10 +22,21 @@ public readonly record struct BoxConstraints(
     /// </summary>
     public static BoxConstraints Unbounded => new(0, PositiveInfinity, 0, PositiveInfinity);
 
+    /// <summary>幅と高さを指定サイズへ固定する制約を作成します。</summary>
+    /// <param name="size">固定する論理ピクセル単位の大きさ。</param>
+    /// <returns>最小値と最大値が指定サイズに等しい制約。</returns>
     public static BoxConstraints Tight(SKSize size) => Tight(size.Width, size.Height);
 
+    /// <summary>幅と高さを指定値へ固定する制約を作成します。</summary>
+    /// <param name="width">固定する論理ピクセル単位の幅。</param>
+    /// <param name="height">固定する論理ピクセル単位の高さ。</param>
+    /// <returns>最小値と最大値が指定値に等しい制約。</returns>
     public static BoxConstraints Tight(double width, double height) => new(width, width, height, height);
 
+    /// <summary>指定された軸だけを固定し、未指定の軸を制限しない制約を作成します。</summary>
+    /// <param name="width">固定する論理ピクセル単位の幅。<see langword="null"/>の場合は幅を固定しません。</param>
+    /// <param name="height">固定する論理ピクセル単位の高さ。<see langword="null"/>の場合は高さを固定しません。</param>
+    /// <returns>指定された軸だけが固定された制約。</returns>
     public static BoxConstraints TightFor(double? width = null, double? height = null) => new()
     {
         MinWidth = width ?? 0,
@@ -28,15 +45,26 @@ public readonly record struct BoxConstraints(
         MaxHeight = height ?? PositiveInfinity
     };
 
+    /// <summary>最小値を0とし、指定値までを許容する緩い制約を作成します。</summary>
+    /// <param name="width">許容する論理ピクセル単位の最大幅。</param>
+    /// <param name="height">許容する論理ピクセル単位の最大高さ。</param>
+    /// <returns>最小値が0で最大値が指定値の制約。</returns>
     public static BoxConstraints Loose(double width, double height) => new()
     {
         MaxHeight = height,
         MaxWidth = width
     };
 
+    /// <summary>最小値を0とし、指定サイズまでを許容する緩い制約を作成します。</summary>
+    /// <param name="size">許容する論理ピクセル単位の最大サイズ。</param>
+    /// <returns>最小値が0で最大値が指定サイズの制約。</returns>
     public static BoxConstraints Loose(SKSize size) => Loose(size.Width, size.Height);
 
 
+    /// <summary>この制約の各境界値を、指定された制約が許容する範囲内へ収めます。</summary>
+    /// <param name="constraints">各境界値の下限と上限として適用する制約。</param>
+    /// <returns>各境界値を指定範囲内へ収めた新しい制約。</returns>
+    /// <exception cref="ArgumentException"><paramref name="constraints"/>のいずれかの最小値が対応する最大値を上回っています。</exception>
     public BoxConstraints Enforce(BoxConstraints constraints) => new(
         Math.Clamp(MinWidth, constraints.MinWidth, constraints.MaxWidth),
         Math.Clamp(MaxWidth, constraints.MinWidth, constraints.MaxWidth),
@@ -44,25 +72,49 @@ public readonly record struct BoxConstraints(
         Math.Clamp(MaxHeight, constraints.MinHeight, constraints.MaxHeight)
     );
 
+    /// <summary>幅をこの制約の最小幅と最大幅の範囲内へ収めます。</summary>
+    /// <param name="width">制約する論理ピクセル単位の幅。</param>
+    /// <returns>許容範囲内へ収めた幅。</returns>
+    /// <exception cref="ArgumentException"><see cref="MinWidth"/>が<see cref="MaxWidth"/>を上回っています。</exception>
     public double ConstrainWidth(double width) => Math.Clamp(width, MinWidth, MaxWidth);
+    /// <summary>高さをこの制約の最小高さと最大高さの範囲内へ収めます。</summary>
+    /// <param name="height">制約する論理ピクセル単位の高さ。</param>
+    /// <returns>許容範囲内へ収めた高さ。</returns>
+    /// <exception cref="ArgumentException"><see cref="MinHeight"/>が<see cref="MaxHeight"/>を上回っています。</exception>
     public double ConstrainHeight(double height) => Math.Clamp(height, MinHeight, MaxHeight);
 
+    /// <summary>最大値を維持したまま、幅と高さの最小値を0にした制約を取得します。</summary>
     public BoxConstraints Loosen => new(0, MaxWidth, 0, MaxHeight);
+    /// <summary>この制約が許容する最小のサイズを取得します。</summary>
+    /// <exception cref="ArgumentException">いずれかの最小値が対応する最大値を上回っています。</exception>
     public SKSize Smallest => new((float)ConstrainWidth(0), (float)ConstrainHeight(0));
 
+    /// <summary>指定サイズをこの制約が許容する範囲内へ収めます。</summary>
+    /// <param name="size">制約する論理ピクセル単位のサイズ。</param>
+    /// <returns>各軸を許容範囲内へ収めたサイズ。</returns>
+    /// <exception cref="ArgumentException">いずれかの最小値が対応する最大値を上回っています。</exception>
     public SKSize Constrain(SKSize size) => Constrain(size.Width, size.Height);
 
+    /// <summary>指定された幅と高さをこの制約が許容する範囲内へ収めます。</summary>
+    /// <param name="width">制約する論理ピクセル単位の幅。</param>
+    /// <param name="height">制約する論理ピクセル単位の高さ。</param>
+    /// <returns>各軸を許容範囲内へ収めたサイズ。</returns>
+    /// <exception cref="ArgumentException">いずれかの最小値が対応する最大値を上回っています。</exception>
     public SKSize Constrain(double width, double height) => new(
         (float)ConstrainWidth(width),
         (float)ConstrainHeight(height)
     );
 
 
+    /// <summary>幅の下限が上限以上であり、自由に選べる幅がないかを取得します。</summary>
     public bool HasTightWidth => MinWidth >= MaxWidth;
+    /// <summary>高さの下限が上限以上であり、自由に選べる高さがないかを取得します。</summary>
     public bool HasTightHeight => MinHeight >= MaxHeight;
 
+    /// <summary>幅と高さの両方について自由に選べる大きさがないかを取得します。</summary>
     public bool IsTight => HasTightWidth && HasTightHeight;
 
+    /// <inheritdoc />
     public override string ToString()
     {
         return $"BoxConstraints {{ width: (min = {MinWidth}, max = {MaxWidth}), height: (min = {MinHeight}, max = {MaxHeight}) }}";

--- a/src/FloatSoda/Geometrics/Color.cs
+++ b/src/FloatSoda/Geometrics/Color.cs
@@ -3,8 +3,20 @@ using SkiaSharp;
 
 namespace FloatSoda.Geometrics;
 
+/// <summary>赤、緑、青、不透明度の各成分を8ビットで表す不変の色値です。</summary>
+/// <param name="Red">赤成分。0から255までで、既定値は255です。</param>
+/// <param name="Green">緑成分。0から255までで、既定値は255です。</param>
+/// <param name="Blue">青成分。0から255までで、既定値は255です。</param>
+/// <param name="Alpha">不透明度。0は完全な透明、255は完全な不透明で、既定値は255です。</param>
+/// <seealso cref="HSVColor"/>
+/// <seealso cref="HSLColor"/>
 public readonly record struct Color(byte Red = 255, byte Green = 255, byte Blue = 255, byte Alpha = 255)
 {
+    /// <summary>ウェブカラー表記から不透明な色値を作成します。</summary>
+    /// <param name="webColor">先頭の番号記号を省略できる3桁または6桁の16進数表記。</param>
+    /// <returns>不透明度が255の色値。</returns>
+    /// <exception cref="ArgumentException"><paramref name="webColor"/>が<see langword="null"/>、空、または空白だけです。</exception>
+    /// <exception cref="FormatException">文字数が3桁または6桁ではないか、16進数以外の文字を含みます。</exception>
     public static Color Parse(string webColor)
     {
         if (string.IsNullOrWhiteSpace(webColor))
@@ -44,13 +56,26 @@ public readonly record struct Color(byte Red = 255, byte Green = 255, byte Blue 
         throw new FormatException($"無効なカラーコード形式です: {webColor}");
     }
 
+    /// <summary>各成分を保持したまま描画用の色へ変換します。</summary>
+    /// <param name="color">変換する色値。</param>
+    /// <returns>同じ赤、緑、青、不透明度を持つ描画用の色。</returns>
     public static implicit operator SKColor(Color color) => new(color.Red, color.Green, color.Blue, color.Alpha);
 
+    /// <summary>描画用の色から各成分を保持した色値へ変換します。</summary>
+    /// <param name="skColor">変換する描画用の色。</param>
+    /// <returns>同じ赤、緑、青、不透明度を持つ色値。</returns>
     public static implicit operator Color(SKColor skColor) => new(skColor.Red, skColor.Green, skColor.Blue, skColor.Alpha);
 }
 
+/// <summary>色相、彩度、明度で色を表す不変値です。</summary>
+/// <param name="Hue">色相を表す0度から360度までの角度。</param>
+/// <param name="Saturation">彩度を表す0パーセントから100パーセントまでの値。</param>
+/// <param name="Value">明度を表す0パーセントから100パーセントまでの値。</param>
+/// <seealso cref="Color"/>
 public readonly record struct HSVColor(double Hue, double Saturation, double Value)
 {
+    /// <summary>0度から360度までの色相を取得します。</summary>
+    /// <exception cref="ArgumentOutOfRangeException">設定値が0未満または360を上回っています。</exception>
     public double Hue
     {
         get;
@@ -61,6 +86,8 @@ public readonly record struct HSVColor(double Hue, double Saturation, double Val
         }
     } = Hue;
 
+    /// <summary>0パーセントから100パーセントまでの彩度を取得します。</summary>
+    /// <exception cref="ArgumentOutOfRangeException">設定値が0未満または100を上回っています。</exception>
     public double Saturation
     {
         get;
@@ -71,6 +98,8 @@ public readonly record struct HSVColor(double Hue, double Saturation, double Val
         }
     } = Saturation;
 
+    /// <summary>0パーセントから100パーセントまでの明度を取得します。</summary>
+    /// <exception cref="ArgumentOutOfRangeException">設定値が0未満または100を上回っています。</exception>
     public double Value
     {
         get;
@@ -81,13 +110,28 @@ public readonly record struct HSVColor(double Hue, double Saturation, double Val
         }
     } = Value;
 
+    /// <summary>赤、緑、青の色値を色相、彩度、明度の表現へ変換します。</summary>
+    /// <param name="color">変換する色値。</param>
+    /// <returns>変換後の色相、彩度、明度。</returns>
+    /// <exception cref="NotImplementedException">この変換は現在実装されていません。</exception>
     public static implicit operator HSVColor(Color color) => throw new NotImplementedException();
 
+    /// <summary>色相、彩度、明度の表現を赤、緑、青の色値へ変換します。</summary>
+    /// <param name="skColor">変換する色相、彩度、明度。</param>
+    /// <returns>変換後の色値。</returns>
+    /// <exception cref="NotImplementedException">この変換は現在実装されていません。</exception>
     public static implicit operator Color(HSVColor skColor) => throw new NotImplementedException();
 }
 
+/// <summary>色相、彩度、輝度で色を表す不変値です。</summary>
+/// <param name="Hue">色相を表す0度から360度までの角度。</param>
+/// <param name="Saturation">彩度を表す0パーセントから100パーセントまでの値。</param>
+/// <param name="Value">輝度を表す0パーセントから100パーセントまでの値。</param>
+/// <seealso cref="Color"/>
 public readonly record struct HSLColor(double Hue, double Saturation, double Value)
 {
+    /// <summary>0度から360度までの色相を取得します。</summary>
+    /// <exception cref="ArgumentOutOfRangeException">設定値が0未満または360を上回っています。</exception>
     public double Hue
     {
         get;
@@ -98,6 +142,8 @@ public readonly record struct HSLColor(double Hue, double Saturation, double Val
         }
     } = Hue;
 
+    /// <summary>0パーセントから100パーセントまでの彩度を取得します。</summary>
+    /// <exception cref="ArgumentOutOfRangeException">設定値が0未満または100を上回っています。</exception>
     public double Saturation
     {
         get;
@@ -108,6 +154,8 @@ public readonly record struct HSLColor(double Hue, double Saturation, double Val
         }
     } = Saturation;
 
+    /// <summary>0パーセントから100パーセントまでの輝度を取得します。</summary>
+    /// <exception cref="ArgumentOutOfRangeException">設定値が0未満または100を上回っています。</exception>
     public double Value
     {
         get;
@@ -118,7 +166,15 @@ public readonly record struct HSLColor(double Hue, double Saturation, double Val
         }
     } = Value;
 
+    /// <summary>赤、緑、青の色値を色相、彩度、輝度の表現へ変換します。</summary>
+    /// <param name="color">変換する色値。</param>
+    /// <returns>変換後の色相、彩度、輝度。</returns>
+    /// <exception cref="NotImplementedException">この変換は現在実装されていません。</exception>
     public static implicit operator HSLColor(Color color) => throw new NotImplementedException();
 
+    /// <summary>色相、彩度、輝度の表現を赤、緑、青の色値へ変換します。</summary>
+    /// <param name="skColor">変換する色相、彩度、輝度。</param>
+    /// <returns>変換後の色値。</returns>
+    /// <exception cref="NotImplementedException">この変換は現在実装されていません。</exception>
     public static implicit operator Color(HSLColor skColor) => throw new NotImplementedException();
 }

--- a/src/FloatSoda/Geometrics/EdgeInsets.cs
+++ b/src/FloatSoda/Geometrics/EdgeInsets.cs
@@ -2,11 +2,25 @@
 
 namespace FloatSoda.Geometrics;
 
+/// <summary>矩形の各辺から内側へ確保する余白を表す不変値です。</summary>
+/// <param name="Left">左辺の余白。単位は論理ピクセルで、既定値は0です。</param>
+/// <param name="Top">上辺の余白。単位は論理ピクセルで、既定値は0です。</param>
+/// <param name="Right">右辺の余白。単位は論理ピクセルで、既定値は0です。</param>
+/// <param name="Bottom">下辺の余白。単位は論理ピクセルで、既定値は0です。</param>
+/// <seealso cref="Offset"/>
 public readonly record struct EdgeInsets(double Left = 0, double Top = 0, double Right = 0, double Bottom = 0)
 {
+    /// <summary>すべての辺の余白が0の値を取得します。</summary>
     public static readonly EdgeInsets Zero = All(0);
+    /// <summary>すべての辺へ同じ余白を設定した値を作成します。</summary>
+    /// <param name="value">各辺へ適用する論理ピクセル単位の余白。</param>
+    /// <returns>すべての辺が同じ余白の新しい値。</returns>
     public static EdgeInsets All(double value) => new(value, value, value, value);
 
+    /// <summary>垂直方向と水平方向でそれぞれ共通の余白を設定した値を作成します。</summary>
+    /// <param name="vertical">上辺と下辺へ適用する論理ピクセル単位の余白。既定値は0です。</param>
+    /// <param name="horizontal">左辺と右辺へ適用する論理ピクセル単位の余白。既定値は0です。</param>
+    /// <returns>軸ごとに対称な余白を持つ新しい値。</returns>
     public static EdgeInsets Symmetric(double vertical = 0, double horizontal = 0) => new()
     {
         Top = vertical,
@@ -15,10 +29,15 @@ public readonly record struct EdgeInsets(double Left = 0, double Top = 0, double
         Right = horizontal
     };
 
+    /// <summary>左辺と上辺の余白をオフセットとして取得します。</summary>
     public Offset TopLeft => new(Left, Top);
+    /// <summary>右辺と上辺の余白をオフセットとして取得します。</summary>
     public Offset TopRight => new(Right, Top);
+    /// <summary>左辺と下辺の余白をオフセットとして取得します。</summary>
     public Offset BottomLeft => new(Left, Bottom);
+    /// <summary>右辺と下辺の余白をオフセットとして取得します。</summary>
     public Offset BottomRight => new(Right, Bottom);
     
+    /// <summary>左辺と右辺、および上辺と下辺を入れ替えた余白を取得します。</summary>
     public EdgeInsets Flipped => new(Right, Bottom, Left, Top);
 }

--- a/src/FloatSoda/Gesture/IHitTestTarget.cs
+++ b/src/FloatSoda/Gesture/IHitTestTarget.cs
@@ -4,15 +4,30 @@ using FloatSoda.Abstractions.Input;
 
 namespace FloatSoda.Gesture;
 
+/// <summary>ヒットテスト経路を通じてポインターイベントを受け取る対象を表します。</summary>
+/// <seealso cref="HitTestEntry"/>
+/// <seealso cref="HitTestResult"/>
 public interface IHitTestTarget
 {
+    /// <summary>この対象が含まれるヒットテスト経路へ配送されたポインターイベントを処理します。</summary>
+    /// <param name="pointerEvent">配送されたポインターイベント。</param>
+    /// <param name="entry">この対象と座標変換を保持するヒットテストエントリ。</param>
     void HandleEvent(PointerEvent pointerEvent, HitTestEntry entry);
 }
 
+/// <summary>ヒットした対象と、その対象のローカル座標へ変換するオフセットを表す不変値です。</summary>
+/// <param name="Target">ポインターイベントを受け取る対象。</param>
+/// <param name="Transform">グローバル座標へ加算して対象のローカル座標へ変換するオフセット。未指定の場合は<see langword="null"/>です。</param>
+/// <seealso cref="IHitTestTarget"/>
+/// <seealso cref="HitTestResult"/>
 public readonly record struct HitTestEntry(IHitTestTarget Target, Offset? Transform = null);
 
+/// <summary>ポインター位置でヒットした対象の経路と、走査中の座標変換を保持します。</summary>
+/// <remarks>座標変換は<see cref="PushOffset"/>と<see cref="PopTransform"/>を対にして管理し、<see cref="Add"/>時点の累積値を各エントリへ保存します。</remarks>
+/// <seealso cref="HitTestEntry"/>
 public class HitTestResult
 {
+    /// <summary>ヒットした対象を配送順に保持する読み取り専用の経路を取得します。</summary>
     public IReadOnlyList<HitTestEntry> Path => _pathInternal;
 
     private readonly List<HitTestEntry> _pathInternal = [];
@@ -37,6 +52,8 @@ public class HitTestResult
         _localTransform.Clear();
     }
 
+    /// <summary>現在のグローバル座標からローカル座標への累積オフセットを取得します。</summary>
+    /// <remarks>まだ確定していないオフセットがある場合は、取得時に累積変換へ反映します。</remarks>
     public Offset LastTransform
     {
         get
@@ -47,8 +64,13 @@ public class HitTestResult
     }
 
 
+    /// <summary>子要素のヒットテスト中に適用する座標オフセットを積みます。</summary>
+    /// <param name="offset">現在の座標へ加算する論理ピクセル単位のオフセット。</param>
+    /// <remarks>走査を戻る際は<see cref="PopTransform"/>を同じ回数だけ呼び出します。</remarks>
     public void PushOffset(Offset offset) => _localTransform.Add(offset);
 
+    /// <summary>直前に積まれた座標オフセットを取り除きます。</summary>
+    /// <remarks><see cref="PushOffset"/>と対にして呼び出す必要があります。未確定のオフセットがあればそれを、なければ確定済みの累積変換を1段戻します。</remarks>
     public void PopTransform()
     {
         if (_localTransform.Count != 0)
@@ -62,8 +84,16 @@ public class HitTestResult
         }
     }
 
+    /// <summary>現在の累積座標変換を設定してヒットテスト経路へエントリを追加します。</summary>
+    /// <param name="entry">追加する対象。指定されている座標変換は現在の累積値で置き換えられます。</param>
     public void Add(HitTestEntry entry) => _pathInternal.Add(entry with { Transform = LastTransform });
 
+    /// <summary>描画時の子要素オフセットを座標へ反映し、子要素のヒットテストを実行します。</summary>
+    /// <param name="offset">親座標系における子要素の論理ピクセル単位の位置。位置がない場合は<see langword="null"/>です。</param>
+    /// <param name="position">親座標系におけるポインター位置。</param>
+    /// <param name="hitTest">この結果と子要素のローカル座標を受け取り、ヒット判定を行う処理。</param>
+    /// <returns>子要素がヒットした場合は<see langword="true"/>、ヒットしなかった場合は<see langword="false"/>。</returns>
+    /// <remarks>指定したオフセットは処理の呼び出し中だけ積まれ、処理が戻ると元の変換状態へ戻されます。</remarks>
     public bool AddWidthPaintOffset(Offset? offset, Offset position, Func<HitTestResult, Offset, bool> hitTest)
     {
         var transform = offset is not null ? position - offset : position;

--- a/src/FloatSoda/RenderObjects/Animation/RenderAnimatedOpacity.cs
+++ b/src/FloatSoda/RenderObjects/Animation/RenderAnimatedOpacity.cs
@@ -7,14 +7,22 @@ namespace FloatSoda.RenderObjects.Animation;
 
 /// <summary>
 /// アニメーションで駆動される不透明度を子に適用するRenderObject。
-/// <see cref="IAnimation{T}.Changed"/>を購読し、値が変わったフレームだけ再ペイントする
+/// <see cref="IListenable.Changed"/>を購読し、値が変わったフレームだけ再ペイントする
 /// (Widgetのリビルドは発生しない)。FlutterのRenderAnimatedOpacity相当。
 /// </summary>
 public class RenderAnimatedOpacity : RenderProxyBox
 {
     private byte? Alpha = null;
 
-    /// <summary>不透明度を駆動するアニメーション(0.0〜1.0)。</summary>
+    /// <summary>不透明度を駆動するアニメーションを取得または設定します。</summary>
+    /// <remarks>
+    /// 値は0.0から1.0の範囲で指定します。
+    /// アタッチ中に参照が変更された場合は以前のアニメーションの購読を解除し、
+    /// 新しいアニメーションを購読して現在値を反映します。
+    /// 反映後のアルファ値が変化した場合、このRenderObjectをPaint Dirtyとしてマークし、
+    /// 次のパイプライン更新時に不透明度レイヤーと子を再描画します。
+    /// 同じ参照が設定された場合、購読とDirty状態は変更されません。
+    /// </remarks>
     public required IAnimation<double> Opacity
     {
         get;
@@ -37,6 +45,7 @@ public class RenderAnimatedOpacity : RenderProxyBox
         }
     }
 
+    /// <inheritdoc/>
     public override void Attach(RenderPipeline? owner)
     {
         base.Attach(owner);
@@ -45,6 +54,7 @@ public class RenderAnimatedOpacity : RenderProxyBox
         UpdateOpacity();
     }
 
+    /// <inheritdoc/>
     public override void Detach()
     {
         Opacity.Changed -= UpdateOpacity;
@@ -61,6 +71,7 @@ public class RenderAnimatedOpacity : RenderProxyBox
         if (oldAlpha != Alpha) MarkNeedsPaint();
     }
 
+    /// <inheritdoc/>
     public override void Paint(PaintingContext context, Offset offset)
     {
         if (Child is null) return;

--- a/src/FloatSoda/RenderObjects/Layout/RenderConstrainedBox.cs
+++ b/src/FloatSoda/RenderObjects/Layout/RenderConstrainedBox.cs
@@ -2,8 +2,19 @@
 
 namespace FloatSoda.RenderObjects.Layout;
 
+/// <summary>
+/// 親から受け取った制約に追加の制約を適用して子をレイアウトするRenderObjectです。
+/// </summary>
 public class RenderConstrainedBox : RenderProxyBox
 {
+    /// <summary>
+    /// 親の制約へ追加して子に適用する制約を取得または設定します。
+    /// </summary>
+    /// <remarks>
+    /// 値が変更された場合、このRenderObjectをLayout Dirtyとしてマークし、
+    /// 次のパイプライン更新時に子のサイズを再計算します。
+    /// 値が変更されなかった場合、Dirty状態は変更されません。
+    /// </remarks>
     public BoxConstraints AdditionalConstraints
     {
         get;
@@ -16,6 +27,7 @@ public class RenderConstrainedBox : RenderProxyBox
         }
     }
 
+    /// <inheritdoc/>
     public override void PerformLayout()
     {
         var enforcedConstraints = AdditionalConstraints.Enforce(Constraints);

--- a/src/FloatSoda/RenderObjects/Layout/RenderFlex.cs
+++ b/src/FloatSoda/RenderObjects/Layout/RenderFlex.cs
@@ -6,33 +6,74 @@ using SkiaSharp;
 
 namespace FloatSoda.RenderObjects.Layout;
 
+/// <summary>
+/// 複数の子を主軸に沿って並べ、主軸と交差軸の配置を調整するRenderObjectです。
+/// </summary>
 public class RenderFlex : RenderBox, IHasMultiChildrenRenderObject
 {
+    /// <summary>
+    /// レイアウト対象となる子のコレクションを取得します。
+    /// </summary>
     public MultiChildrenCollection<RenderBox> Children { get; }
 
+    /// <summary>
+    /// 子を持たないFlexレイアウトを初期化します。
+    /// </summary>
     public RenderFlex() => Children = new MultiChildrenCollection<RenderBox>(this);
 
+    /// <summary>
+    /// 指定したRenderObjectを末尾の子として追加します。
+    /// </summary>
+    /// <param name="child">追加するRenderObject。<see cref="RenderBox"/>である必要があります。</param>
+    /// <remarks>
+    /// このRenderObjectをLayout Dirtyとしてマークし、
+    /// 次のパイプライン更新時に全ての子のサイズと位置を再計算します。
+    /// </remarks>
     public void AddChild(RenderObject child) => Children.Add((RenderBox)child);
+
+    /// <summary>
+    /// 指定したRenderObjectを子のコレクションから削除します。
+    /// </summary>
+    /// <param name="child">削除するRenderObject。<see cref="RenderBox"/>である必要があります。</param>
+    /// <returns>子が見つかり削除された場合は<c>true</c>、それ以外の場合は<c>false</c>。</returns>
+    /// <remarks>
+    /// 子が削除された場合、このRenderObjectをLayout Dirtyとしてマークし、
+    /// 次のパイプライン更新時に残りの子のサイズと位置を再計算します。
+    /// 子が見つからなかった場合、Dirty状態は変更されません。
+    /// </remarks>
     public bool RemoveChild(RenderObject child) => Children.Remove((RenderBox)child);
 
+    /// <inheritdoc/>
     public override void SetupParentData(RenderObject child) => child.ParentData = new BoxParentData();
 
+    /// <inheritdoc/>
     public override void Attach(RenderPipeline? owner)
     {
         base.Attach(owner);
         Children.Attach(owner);
     }
 
+    /// <inheritdoc/>
     public override void Detach()
     {
         base.Detach();
         Children.Detach();
     }
 
+    /// <inheritdoc/>
     public override void VisitChildren(Action<RenderObject> visitor) => Children.VisitChildren(visitor);
 
+    /// <inheritdoc/>
     public override void RedepthChildren() => VisitChildren(RedepthChild);
 
+    /// <summary>
+    /// 子を並べる主軸の方向を取得または設定します。
+    /// </summary>
+    /// <remarks>
+    /// 値が変更された場合、このRenderObjectをLayout Dirtyとしてマークし、
+    /// 次のパイプライン更新時に各子のサイズと位置を再計算します。
+    /// 値が変更されなかった場合、Dirty状態は変更されません。
+    /// </remarks>
     public Axis Direction
     {
         get;
@@ -44,6 +85,14 @@ public class RenderFlex : RenderBox, IHasMultiChildrenRenderObject
         }
     } = Axis.Vertical;
 
+    /// <summary>
+    /// 主軸方向の子の配置方法を取得または設定します。
+    /// </summary>
+    /// <remarks>
+    /// 値が変更された場合、このRenderObjectをLayout Dirtyとしてマークし、
+    /// 次のパイプライン更新時に主軸方向の余白と各子の位置を再計算します。
+    /// 値が変更されなかった場合、Dirty状態は変更されません。
+    /// </remarks>
     public MainAxisAlignment MainAxisAlignment
     {
         get;
@@ -55,6 +104,14 @@ public class RenderFlex : RenderBox, IHasMultiChildrenRenderObject
         }
     } = MainAxisAlignment.Start;
 
+    /// <summary>
+    /// 主軸方向に利用可能な領域を占有する方法を取得または設定します。
+    /// </summary>
+    /// <remarks>
+    /// 値が変更された場合、このRenderObjectをLayout Dirtyとしてマークし、
+    /// 次のパイプライン更新時に主軸方向のサイズと各子の位置を再計算します。
+    /// 値が変更されなかった場合、Dirty状態は変更されません。
+    /// </remarks>
     public MainAxisSize MainAxisSize
     {
         get;
@@ -66,6 +123,14 @@ public class RenderFlex : RenderBox, IHasMultiChildrenRenderObject
         }
     } = MainAxisSize.Max;
 
+    /// <summary>
+    /// 交差軸方向の子の配置方法を取得または設定します。
+    /// </summary>
+    /// <remarks>
+    /// 値が変更された場合、このRenderObjectをLayout Dirtyとしてマークし、
+    /// 次のパイプライン更新時に交差軸方向の制約と各子の位置を再計算します。
+    /// 値が変更されなかった場合、Dirty状態は変更されません。
+    /// </remarks>
     public CrossAxisAlignment CrossAxisAlignment
     {
         get;
@@ -77,6 +142,14 @@ public class RenderFlex : RenderBox, IHasMultiChildrenRenderObject
         }
     } = CrossAxisAlignment.Center;
 
+    /// <summary>
+    /// 垂直方向における開始側と終了側の向きを取得または設定します。
+    /// </summary>
+    /// <remarks>
+    /// 値が変更された場合、このRenderObjectをLayout Dirtyとしてマークし、
+    /// 次のパイプライン更新時に各子の配置順と位置を再計算します。
+    /// 値が変更されなかった場合、Dirty状態は変更されません。
+    /// </remarks>
     public VerticalDirection VerticalDirection
     {
         get;
@@ -192,6 +265,7 @@ public class RenderFlex : RenderBox, IHasMultiChildrenRenderObject
         }
     }
 
+    /// <inheritdoc/>
     public override void PerformLayout()
     {
         MeasureCrossAxis(Constraints, out var allocatedSize, out var crossSize);
@@ -224,6 +298,7 @@ public class RenderFlex : RenderBox, IHasMultiChildrenRenderObject
     }
 
 
+    /// <inheritdoc/>
     public override void Paint(PaintingContext context, Offset offset)
     {
         foreach (var child in Children)
@@ -235,6 +310,7 @@ public class RenderFlex : RenderBox, IHasMultiChildrenRenderObject
         }
     }
 
+    /// <inheritdoc/>
     public override bool HitTestChildren(HitTestResult result, Offset position)
     {
         // 描画順の逆（手前に描かれた子から）に判定し、最初にヒットした子で打ち切る

--- a/src/FloatSoda/RenderObjects/Layout/RenderPositionedBox.cs
+++ b/src/FloatSoda/RenderObjects/Layout/RenderPositionedBox.cs
@@ -6,20 +6,44 @@ using static System.Double;
 
 namespace FloatSoda.RenderObjects.Layout;
 
+/// <summary>
+/// 自身の領域内で子を指定した配置に位置決めするRenderObjectです。
+/// </summary>
 public class RenderPositionedBox : RenderBox, IHasSingleChildRenderObject
 {
     private readonly SingleChildContainer<RenderObject> _child;
 
+    /// <summary>
+    /// 子を持たない位置決め用RenderObjectを初期化します。
+    /// </summary>
     public RenderPositionedBox() => _child = new SingleChildContainer<RenderObject>(this);
 
+    /// <summary>
+    /// 配置する子を取得または設定します。
+    /// </summary>
+    /// <remarks>
+    /// 子を差し替えると、このRenderObjectをLayout Dirtyとしてマークし、
+    /// 次のパイプライン更新時に自身のサイズと子の位置を再計算します。
+    /// 同じ子を再設定した場合も、子の取り外しと追加が行われるためLayout Dirtyとなります。
+    /// </remarks>
     public RenderObject? Child
     {
         get => _child.Child;
         set => _child.Child = value;
     }
 
+    /// <inheritdoc/>
     public override void SetupParentData(RenderObject child) => child.ParentData = new BoxParentData();
 
+    /// <summary>
+    /// 子の幅に乗算して自身の幅を決める係数を取得または設定します。
+    /// </summary>
+    /// <remarks>
+    /// <c>null</c>の場合、有限の親制約では利用可能な最大幅を使用します。
+    /// 値が変更された場合、このRenderObjectをLayout Dirtyとしてマークし、
+    /// 次のパイプライン更新時に自身のサイズと子の位置を再計算します。
+    /// 値が変更されなかった場合、Dirty状態は変更されません。
+    /// </remarks>
     public double? WidthFactor
     {
         get;
@@ -31,6 +55,15 @@ public class RenderPositionedBox : RenderBox, IHasSingleChildRenderObject
         }
     }
 
+    /// <summary>
+    /// 子の高さに乗算して自身の高さを決める係数を取得または設定します。
+    /// </summary>
+    /// <remarks>
+    /// <c>null</c>の場合、有限の親制約では利用可能な最大高さを使用します。
+    /// 値が変更された場合、このRenderObjectをLayout Dirtyとしてマークし、
+    /// 次のパイプライン更新時に自身のサイズと子の位置を再計算します。
+    /// 値が変更されなかった場合、Dirty状態は変更されません。
+    /// </remarks>
     public double? HeightFactor
     {
         get;
@@ -43,6 +76,14 @@ public class RenderPositionedBox : RenderBox, IHasSingleChildRenderObject
     }
 
 
+    /// <summary>
+    /// 自身の領域内で子を配置する位置を取得または設定します。
+    /// </summary>
+    /// <remarks>
+    /// 値が変更された場合、このRenderObjectをLayout Dirtyとしてマークし、
+    /// 次のパイプライン更新時に子のオフセットを再計算します。
+    /// 値が変更されなかった場合、Dirty状態は変更されません。
+    /// </remarks>
     public Alignment Alignment
     {
         get;
@@ -56,6 +97,7 @@ public class RenderPositionedBox : RenderBox, IHasSingleChildRenderObject
     } = default;
 
 
+    /// <inheritdoc/>
     public override void PerformLayout()
     {
         var shrinkWrapWidth = WidthFactor.HasValue || IsPositiveInfinity(Constraints.MaxWidth);
@@ -89,6 +131,7 @@ public class RenderPositionedBox : RenderBox, IHasSingleChildRenderObject
         childParentData.Offset = offset;
     }
 
+    /// <inheritdoc/>
     public override void Paint(PaintingContext context, Offset offset)
     {
         if (Child == null) return;
@@ -97,22 +140,27 @@ public class RenderPositionedBox : RenderBox, IHasSingleChildRenderObject
         context.PaintChild(Child, offset + (childParentData?.Offset ?? Offset.Zero));
     }
 
+    /// <inheritdoc/>
     public override void Attach(RenderPipeline? owner)
     {
         base.Attach(owner);
         _child.Attach(owner);
     }
 
+    /// <inheritdoc/>
     public override void Detach()
     {
         base.Detach();
         _child.Detach();
     }
 
+    /// <inheritdoc/>
     public override void VisitChildren(Action<RenderObject> visitor) => _child.VisitChildren(visitor);
 
+    /// <inheritdoc/>
     public override void RedepthChildren() => VisitChildren(RedepthChild);
 
+    /// <inheritdoc/>
     public override bool HitTestChildren(HitTestResult result, Offset position)
     {
         if (Child is null) return false;

--- a/src/FloatSoda/RenderObjects/Painting/RenderColoredBox.cs
+++ b/src/FloatSoda/RenderObjects/Painting/RenderColoredBox.cs
@@ -4,8 +4,19 @@ using SkiaSharp;
 
 namespace FloatSoda.RenderObjects.Painting;
 
+/// <summary>
+/// 自身の領域を単色で塗りつぶし、その上に子を描画するRenderObjectです。
+/// </summary>
 public class RenderColoredBox : RenderProxyBox
 {
+    /// <summary>
+    /// 背景の塗りつぶし色を取得または設定します。
+    /// </summary>
+    /// <remarks>
+    /// 値が変更された場合、このRenderObjectをPaint Dirtyとしてマークし、
+    /// 次のパイプライン更新時に背景と子を再描画します。
+    /// 値が変更されなかった場合、Dirty状態は変更されません。
+    /// </remarks>
     public SKColor Color
     {
         get;
@@ -17,6 +28,7 @@ public class RenderColoredBox : RenderProxyBox
         }
     } = SKColors.Black;
 
+    /// <inheritdoc/>
     public override void Paint(PaintingContext context, Offset offset)
     {
         if (!Size.IsEmpty)
@@ -28,6 +40,7 @@ public class RenderColoredBox : RenderProxyBox
     }
 
 
+    /// <inheritdoc/>
     public override bool HitTest(HitTestResult result, Offset position)
     {
         if (!Size.Contains(position)) return false;
@@ -42,5 +55,6 @@ public class RenderColoredBox : RenderProxyBox
         return hitTarget;
     }
 
+    /// <inheritdoc/>
     public override bool HitTestSelf(Offset position) => true;
 }

--- a/src/FloatSoda/RenderObjects/Painting/RenderCustomClip.cs
+++ b/src/FloatSoda/RenderObjects/Painting/RenderCustomClip.cs
@@ -5,15 +5,42 @@ using SkiaSharp;
 
 namespace FloatSoda.RenderObjects.Painting;
 
+/// <summary>
+/// RenderObjectのサイズから任意のクリップ領域を生成する基底クラスです。
+/// </summary>
+/// <typeparam name="T">生成するクリップ領域の型。</typeparam>
 public abstract class CustomClipper<T>
 {
+    /// <summary>
+    /// 指定したサイズに対応するクリップ領域を生成します。
+    /// </summary>
+    /// <param name="size">クリップ対象となるRenderObjectのサイズ。</param>
+    /// <returns>生成されたクリップ領域。</returns>
     public abstract T GetClip(SKSize size);
 
+    /// <summary>
+    /// 以前のクリッパーからクリップ領域を再生成する必要があるかを判定します。
+    /// </summary>
+    /// <param name="oldClipper">以前使用していたクリッパー。</param>
+    /// <returns>クリップ領域を再生成する必要がある場合は<c>true</c>、再利用できる場合は<c>false</c>。</returns>
     public abstract bool ShouldReclip(CustomClipper<T> oldClipper);
 }
 
+/// <summary>
+/// 子の描画を任意の形状で切り抜くRenderObjectの基底クラスです。
+/// </summary>
+/// <typeparam name="T">クリップ領域を表す型。</typeparam>
 public abstract class RenderCustomClip<T> : RenderProxyBox
 {
+    /// <summary>
+    /// クリップ領域を生成するクリッパーを取得または設定します。
+    /// </summary>
+    /// <remarks>
+    /// クリッパーが追加または削除された場合、型が変わった場合、または新しいクリッパーが
+    /// 再生成を要求した場合、このRenderObjectをPaint Dirtyとしてマークし、
+    /// 次のパイプライン更新時にクリップ領域と子を再描画します。
+    /// 同じクリッパーが設定された場合、またはクリップ領域を再利用できる場合、Dirty状態は変更されません。
+    /// </remarks>
     public CustomClipper<T>? Clipper
     {
         get;
@@ -33,6 +60,14 @@ public abstract class RenderCustomClip<T> : RenderProxyBox
     }
 
 
+    /// <summary>
+    /// クリップ境界に適用する描画品質を取得または設定します。
+    /// </summary>
+    /// <remarks>
+    /// 値が変更された場合、このRenderObjectをPaint Dirtyとしてマークし、
+    /// 次のパイプライン更新時に指定した品質で子を再描画します。
+    /// 値が変更されなかった場合、Dirty状態は変更されません。
+    /// </remarks>
     public Clip ClipBehavior
     {
         get;
@@ -44,12 +79,18 @@ public abstract class RenderCustomClip<T> : RenderProxyBox
         }
     } = FloatSoda.Rendering.Layers.Clip.Antialias;
 
+    /// <summary>現在のサイズに対して有効なクリップ領域を取得します。</summary>
+    /// <value><see cref="Clipper"/>が設定されている場合はその生成結果、それ以外は<see cref="DefaultClip"/>。</value>
     protected T Clip => Clipper != null ? Clipper.GetClip(Size) : DefaultClip;
 
+    /// <summary><see cref="Clipper"/>が未設定のときに使用する既定のクリップ領域を取得します。</summary>
+    /// <value>このRenderObjectの現在のサイズ全体を覆う領域。</value>
     protected abstract T DefaultClip { get; }
 
+    /// <summary>このRenderObjectをPaint Dirtyとしてマークし、次のパイプライン更新時にクリップ領域を再計算します。</summary>
     protected void MarkNeedsClip() => MarkNeedsPaint();
 
+    /// <inheritdoc/>
     public override void PerformLayout()
     {
         var oldSize = Size;
@@ -60,10 +101,15 @@ public abstract class RenderCustomClip<T> : RenderProxyBox
     }
 }
 
+/// <summary>
+/// 子の描画を矩形領域で切り抜くRenderObjectです。
+/// </summary>
 public class RenderClipRect : RenderCustomClip<SKRect>
 {
+    /// <inheritdoc/>
     protected override SKRect DefaultClip => SKRect.Create(Offset.Zero, Size);
 
+    /// <inheritdoc/>
     public override void Paint(PaintingContext context, Offset offset)
     {
         if (Child != null)
@@ -81,12 +127,24 @@ public class RenderClipRect : RenderCustomClip<SKRect>
     }
 }
 
+/// <summary>
+/// 子の描画を角丸矩形領域で切り抜くRenderObjectです。
+/// </summary>
 public class RenderClipRoundRect : RenderCustomClip<SKRoundRect>
 {
+    /// <summary>
+    /// 既定のクリップ領域に適用する角の半径を取得または設定します。
+    /// </summary>
+    /// <remarks>
+    /// このプロパティの設定だけではDirty状態は変更されません。
+    /// 変更後に再描画が要求されたとき、新しい角の半径がクリップ領域へ反映されます。
+    /// </remarks>
     public BorderRadius BorderRadius { get; set; }
 
+    /// <inheritdoc/>
     protected override SKRoundRect DefaultClip => BorderRadius.ToRoundRect(SKRect.Create(Offset.Zero, Size));
 
+    /// <inheritdoc/>
     public override void Paint(PaintingContext context, Offset offset)
     {
         if (Child != null)
@@ -107,8 +165,12 @@ public class RenderClipRoundRect : RenderCustomClip<SKRoundRect>
     }
 }
 
+/// <summary>
+/// 子の描画をパス領域で切り抜くRenderObjectです。
+/// </summary>
 public class RenderClipPath : RenderCustomClip<SKPath>
 {
+    /// <inheritdoc/>
     protected override SKPath DefaultClip
     {
         get
@@ -119,6 +181,7 @@ public class RenderClipPath : RenderCustomClip<SKPath>
         }
     }
 
+    /// <inheritdoc/>
     public override void Paint(PaintingContext context, Offset offset)
     {
         if (Child != null)
@@ -139,10 +202,15 @@ public class RenderClipPath : RenderCustomClip<SKPath>
     }
 }
 
+/// <summary>
+/// 子の描画を楕円領域で切り抜くRenderObjectです。
+/// </summary>
 public class RenderClipOval : RenderCustomClip<SKRect>
 {
+    /// <inheritdoc/>
     protected override SKRect DefaultClip => SKRect.Create(Offset.Zero, Size);
 
+    /// <inheritdoc/>
     public override void Paint(PaintingContext context, Offset offset)
     {
         if (Child == null) return;

--- a/src/FloatSoda/RenderObjects/RenderImage.cs
+++ b/src/FloatSoda/RenderObjects/RenderImage.cs
@@ -3,10 +3,17 @@ using SkiaSharp;
 
 namespace FloatSoda.RenderObjects;
 
+/// <summary>
+/// 画像を自身の領域へ拡縮して描画し、その上に任意の子を描画するRenderObjectです。
+/// </summary>
 public class RenderImage : RenderProxyBox
 {
+    /// <summary>
+    /// 描画する画像を取得します。
+    /// </summary>
     public required SKImage Image { get; init; }
 
+    /// <inheritdoc/>
     public override void PerformLayout()
     {
         if (Child != null)
@@ -20,6 +27,7 @@ public class RenderImage : RenderProxyBox
         }
     }
 
+    /// <inheritdoc/>
     public override void Paint(PaintingContext context, Offset offset)
     {
         context.Canvas.DrawImage(Image, SKRect.Create(offset, Size));

--- a/src/FloatSoda/RenderObjects/RenderObjectMixin.cs
+++ b/src/FloatSoda/RenderObjects/RenderObjectMixin.cs
@@ -29,9 +29,14 @@ public interface IHasMultiChildrenRenderObject
 /// 単一の子の保持をコンポジションで提供するコンテナ。子の差し替え時にownerへのAdopt/Dropを行い、
 /// ライフサイクル(Attach/Detach/Visit)の転送ヘルパーを提供する。
 /// </summary>
+/// <param name="owner">子を所有し、追加と削除の通知を受け取るRenderObject。</param>
 public class SingleChildContainer<T>(RenderObject owner) where T : RenderObject
 {
     /// <summary>保持している子。差し替え時は旧子をDropし新子をAdoptする。</summary>
+    /// <remarks>
+    /// 子を差し替えると、所有者をLayout Dirtyとしてマークします。
+    /// 同じ子を再設定した場合も、子の取り外しと追加が行われるためLayout Dirtyとなります。
+    /// </remarks>
     public T? Child
     {
         get;
@@ -60,23 +65,38 @@ public class SingleChildContainer<T>(RenderObject owner) where T : RenderObject
 /// 複数の子の保持をコンポジションで提供するコレクション。追加・削除時にownerへのAdopt/Dropを行い、
 /// ライフサイクル(Attach/Detach/Visit)の転送ヘルパーを提供する。
 /// </summary>
+/// <param name="owner">子を所有し、追加と削除の通知を受け取るRenderObject。</param>
 public class MultiChildrenCollection<T>(RenderObject owner) : ICollection<T> where T : RenderObject
 {
     private readonly List<T> _children = [];
 
+    /// <summary>保持している子の数を取得する。</summary>
     public int Count => _children.Count;
+
+    /// <summary>コレクションが読み取り専用かどうかを取得する。</summary>
     public bool IsReadOnly => false;
 
     /// <summary>子を末尾に追加する。</summary>
+    /// <remarks>
+    /// 所有者をLayout Dirtyとしてマークし、次のパイプライン更新時に再レイアウトを要求します。
+    /// </remarks>
     public void Add(T child)
     {
         owner.AdoptChild(child);
         _children.Add(child);
     }
 
+    /// <summary>保持している子を指定した配列へコピーする。</summary>
+    /// <param name="array">子をコピーする配列。</param>
+    /// <param name="arrayIndex">コピーを開始する配列の位置。</param>
     public void CopyTo(T[] array, int arrayIndex) => _children.CopyTo(array, arrayIndex);
 
     /// <summary>子を取り除く。</summary>
+    /// <remarks>
+    /// 子が削除された場合、所有者をLayout Dirtyとしてマークし、
+    /// 次のパイプライン更新時に再レイアウトを要求します。
+    /// 子が見つからなかった場合、Dirty状態は変更されません。
+    /// </remarks>
     public bool Remove(T child)
     {
         if (!_children.Remove(child)) return false;
@@ -86,6 +106,10 @@ public class MultiChildrenCollection<T>(RenderObject owner) : ICollection<T> whe
     }
 
     /// <summary>全ての子を取り除く。</summary>
+    /// <remarks>
+    /// 子を一つ取り除くたびに所有者へLayout Dirtyを要求します。
+    /// コレクションが空の場合、Dirty状態は変更されません。
+    /// </remarks>
     public void Clear()
     {
         foreach (var child in _children)
@@ -96,6 +120,9 @@ public class MultiChildrenCollection<T>(RenderObject owner) : ICollection<T> whe
         _children.Clear();
     }
 
+    /// <summary>指定した子を保持しているかを判定する。</summary>
+    /// <param name="item">検索する子。</param>
+    /// <returns>指定した子を保持している場合は<c>true</c>、それ以外の場合は<c>false</c>。</returns>
     public bool Contains(T item) => _children.Contains(item);
 
     /// <summary>全ての子をRenderPipelineへアタッチする。ownerのAttachから呼ぶ。</summary>
@@ -125,6 +152,8 @@ public class MultiChildrenCollection<T>(RenderObject owner) : ICollection<T> whe
         }
     }
 
+    /// <summary>保持している子を列挙する反復子を取得する。</summary>
+    /// <returns>子を列挙する反復子。</returns>
     public IEnumerator<T> GetEnumerator() => _children.GetEnumerator();
 
     IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
@@ -136,6 +165,10 @@ public class MultiChildrenCollection<T>(RenderObject owner) : ICollection<T> whe
 public static class MultiChildrenCollectionExtensions
 {
     /// <summary>保持している子を指定した子の一覧で置き換える。</summary>
+    /// <remarks>
+    /// 既存の子の取り外しと新しい子の追加により、所有者をLayout Dirtyとしてマークします。
+    /// 既存の子と指定した子がどちらも空の場合、Dirty状態は変更されません。
+    /// </remarks>
     public static void Swap<T>(this MultiChildrenCollection<T> collection, ReadOnlySpan<T> children)
         where T : RenderObject
     {
@@ -148,10 +181,18 @@ public static class MultiChildrenCollectionExtensions
     }
 
     /// <summary><see cref="RenderObject"/>を要素型へ変換して末尾に追加する。Element境界の非総称な挿入に使う。</summary>
+    /// <remarks>
+    /// コレクションの所有者をLayout Dirtyとしてマークし、
+    /// 次のパイプライン更新時に再レイアウトを要求します。
+    /// </remarks>
     public static void AddErased<T>(this MultiChildrenCollection<T> collection, RenderObject child)
         where T : RenderObject => collection.Add((T)child);
 
     /// <summary><see cref="RenderObject"/>を要素型として取り除く。要素型でない・保持していない場合は false。</summary>
+    /// <remarks>
+    /// 子が削除された場合、コレクションの所有者をLayout Dirtyとしてマークします。
+    /// 型が一致しない場合、または子が見つからなかった場合、Dirty状態は変更されません。
+    /// </remarks>
     public static bool RemoveErased<T>(this MultiChildrenCollection<T> collection, RenderObject child)
         where T : RenderObject => child is T typed && collection.Remove(typed);
 }

--- a/src/FloatSoda/RenderObjects/RenderParagraph.cs
+++ b/src/FloatSoda/RenderObjects/RenderParagraph.cs
@@ -6,32 +6,51 @@ using HitTestResult = FloatSoda.Gesture.HitTestResult;
 
 namespace FloatSoda.RenderObjects;
 
+/// <summary>
+/// 書式付きテキストを計測して描画するRenderObjectです。
+/// </summary>
 public class RenderParagraph : RenderBox, IHasMultiChildrenRenderObject
 {
+    /// <summary>
+    /// テキスト内の埋め込み要素に対応する子のコレクションを取得します。
+    /// </summary>
     public MultiChildrenCollection<RenderBox> Children { get; }
 
     void IHasMultiChildrenRenderObject.AddChild(RenderObject child) => Children.AddErased(child);
 
     bool IHasMultiChildrenRenderObject.RemoveChild(RenderObject child) => Children.RemoveErased(child);
 
+    /// <inheritdoc/>
     public override void SetupParentData(RenderObject child) => child.ParentData = new BoxParentData();
 
+    /// <inheritdoc/>
     public override void Attach(RenderPipeline? owner)
     {
         base.Attach(owner);
         Children.Attach(owner);
     }
 
+    /// <inheritdoc/>
     public override void Detach()
     {
         base.Detach();
         Children.Detach();
     }
 
+    /// <inheritdoc/>
     public override void VisitChildren(Action<RenderObject> visitor) => Children.VisitChildren(visitor);
 
+    /// <inheritdoc/>
     public override void RedepthChildren() => VisitChildren(RedepthChild);
 
+    /// <summary>
+    /// 計測および描画する書式付きテキストを取得または設定します。
+    /// </summary>
+    /// <remarks>
+    /// 値が変更された場合、内部の計測結果を破棄し、このRenderObjectをLayout Dirtyとしてマークします。
+    /// 次のパイプライン更新時にテキストのサイズを再計算し、必要に応じて再描画します。
+    /// 値が変更されなかった場合、Dirty状態は変更されません。
+    /// </remarks>
     public required TextSpan Text
     {
         get;
@@ -46,33 +65,66 @@ public class RenderParagraph : RenderBox, IHasMultiChildrenRenderObject
 
     private readonly TextPainter _textPainter = new();
 
+    /// <summary>
+    /// 子を持たない段落描画用RenderObjectを初期化します。
+    /// </summary>
     public RenderParagraph()
     {
         Children = new MultiChildrenCollection<RenderBox>(this);
     }
 
+    /// <inheritdoc/>
     public override void PerformLayout()
     {
         _textPainter.Layout(Constraints.MinWidth, Constraints.MaxWidth);
         Size = Constraints.Constrain(_textPainter.Size);
     }
 
+    /// <inheritdoc/>
     public override void Paint(PaintingContext context, Offset offset) => _textPainter.Paint(context.Canvas, offset);
 
+    /// <inheritdoc/>
     public override bool HitTestSelf(Offset position) => true;
 
+    /// <inheritdoc/>
     public override bool HitTestChildren(HitTestResult result, Offset position) => false;
 }
 
+/// <summary>
+/// 文字列とその書式を表すテキスト範囲です。
+/// </summary>
+/// <param name="Text">この範囲に含める文字列。</param>
 public record TextSpan(string Text)
 {
+    /// <summary>
+    /// この範囲へ適用する書式を取得します。
+    /// </summary>
+    /// <remarks>
+    /// <c>null</c>の場合、構築時に渡された既定の書式を使用します。
+    /// </remarks>
     public Style? Style { get; init; }
 
+    /// <summary>
+    /// この範囲の文字列を書式付きテキストブロックへ追加します。
+    /// </summary>
+    /// <param name="textBlock">文字列を追加するテキストブロック。</param>
+    /// <param name="defaultStyle"><see cref="Style"/>が<c>null</c>の場合に使用する書式。</param>
     public void Build(TextBlock textBlock, Style defaultStyle) => textBlock.AddText(Text, Style ?? defaultStyle);
 }
 
+/// <summary>
+/// 書式付きテキストの計測結果を保持し、レイアウトと描画を行います。
+/// </summary>
 public class TextPainter
 {
+    /// <summary>
+    /// 計測および描画する書式付きテキストを取得または設定します。
+    /// </summary>
+    /// <remarks>
+    /// 値が変更された場合、保持している計測結果を破棄します。
+    /// 次に<see cref="Layout"/>を呼び出したとき、テキストブロックが再構築されます。
+    /// 値が変更されなかった場合、保持している計測結果は変更されません。
+    /// </remarks>
     public TextSpan? Text
     {
         get;
@@ -85,8 +137,20 @@ public class TextPainter
     }
 
     private TextBlock? _textBlock;
+
+    /// <summary>
+    /// 最後にレイアウトしたテキストのサイズを取得します。
+    /// </summary>
     public SKSize Size => new((float)Width, (float)Height);
+
+    /// <summary>
+    /// 最後にレイアウトしたテキストの幅を取得します。
+    /// </summary>
     public double Width => _textBlock?.MeasuredWidth ?? 0;
+
+    /// <summary>
+    /// 最後にレイアウトしたテキストの高さを取得します。
+    /// </summary>
     public double Height => _textBlock?.MeasuredHeight ?? 0;
 
     private void MarkNeedsLayout() => _textBlock = null;
@@ -105,6 +169,11 @@ public class TextPainter
     }
 
 
+    /// <summary>
+    /// 指定した幅の範囲でテキストを計測します。
+    /// </summary>
+    /// <param name="minWidth">最小幅。現在の実装では計測に使用されません。</param>
+    /// <param name="maxWidth">改行に使用する最大幅。</param>
     public void Layout(double minWidth, double maxWidth)
     {
         _textBlock ??= CreateTextBlock();
@@ -114,5 +183,10 @@ public class TextPainter
     }
 
 
+    /// <summary>
+    /// 最後にレイアウトしたテキストを指定位置へ描画します。
+    /// </summary>
+    /// <param name="canvas">描画先のキャンバス。</param>
+    /// <param name="offset">キャンバス上の描画開始位置。</param>
     public void Paint(SKCanvas canvas, Offset offset) => _textBlock?.Paint(canvas, offset);
 }

--- a/src/FloatSoda/RenderObjects/RenderView.cs
+++ b/src/FloatSoda/RenderObjects/RenderView.cs
@@ -8,12 +8,24 @@ using SkiaSharp;
 
 namespace FloatSoda.RenderObjects;
 
+/// <summary>
+/// RenderObjectツリーのルートとして、表示領域のサイズ、初期レイアウト、初期描画を管理します。
+/// </summary>
 public class RenderView : RenderObject, IHasSingleChildRenderObject
 {
+    /// <inheritdoc/>
     public override SKSize Size { get; protected set; }
 
     private readonly SingleChildContainer<RenderBox> _child;
 
+    /// <summary>
+    /// 表示領域へ配置するルートの子を取得または設定します。
+    /// </summary>
+    /// <remarks>
+    /// 子を差し替えると、このRenderObjectをLayout Dirtyとしてマークし、
+    /// 次のパイプライン更新時に表示領域と子のサイズを再計算します。
+    /// 同じ子を再設定した場合も、子の取り外しと追加が行われるためLayout Dirtyとなります。
+    /// </remarks>
     public RenderBox? Child
     {
         get => _child.Child;
@@ -26,17 +38,28 @@ public class RenderView : RenderObject, IHasSingleChildRenderObject
         set => Child = (RenderBox?)value;
     }
 
+    /// <summary>
+    /// 指定した初期サイズでRenderObjectツリーのルートを初期化します。
+    /// </summary>
+    /// <param name="width">初期の表示幅。</param>
+    /// <param name="height">初期の表示高さ。</param>
     public RenderView(float width = 1000, float height = 1000)
     {
         Size = new SKSize(width, height);
         _child = new SingleChildContainer<RenderBox>(this);
     }
 
+    /// <inheritdoc/>
     public override bool IsRepaintBoundary => true;
 
     /// <summary>
     /// ウィンドウの固定サイズ。null の場合は子のレイアウト結果サイズに追従します。
     /// </summary>
+    /// <remarks>
+    /// 値が変更された場合、このRenderObjectをLayout Dirtyとしてマークし、
+    /// 次のパイプライン更新時に表示領域と子のサイズを再計算します。
+    /// 値が変更されなかった場合、Dirty状態は変更されません。
+    /// </remarks>
     public SKSize? FixedSize
     {
         get;
@@ -69,27 +92,39 @@ public class RenderView : RenderObject, IHasSingleChildRenderObject
     }
 
 
+    /// <inheritdoc/>
     public override void Paint(PaintingContext context, Offset offset)
     {
         if (Child != null) context.PaintChild(Child, offset);
     }
 
+    /// <inheritdoc/>
     public override void Attach(RenderPipeline? owner)
     {
         base.Attach(owner);
         _child.Attach(owner);
     }
 
+    /// <inheritdoc/>
     public override void Detach()
     {
         base.Detach();
         _child.Detach();
     }
 
+    /// <inheritdoc/>
     public override void VisitChildren(Action<RenderObject> visitor) => _child.VisitChildren(visitor);
 
+    /// <inheritdoc/>
     public override void RedepthChildren() => VisitChildren(RedepthChild);
 
+    /// <summary>
+    /// 最初のフレームに必要なレイアウトと描画をパイプラインへ登録します。
+    /// </summary>
+    /// <remarks>
+    /// このRenderObjectをLayout DirtyおよびPaint Dirtyの処理対象として登録し、
+    /// 自身をレイアウト境界、生成したルートレイヤーを再描画境界として設定します。
+    /// </remarks>
     public void PrepareInitialFrame()
     {
         ScheduleInitialLayout();
@@ -108,6 +143,12 @@ public class RenderView : RenderObject, IHasSingleChildRenderObject
         Owner?.NodesNeedingLayout.Add(this);
     }
 
+    /// <summary>
+    /// 指定位置に対して子からルートまでのヒットテスト結果を構築します。
+    /// </summary>
+    /// <param name="result">ヒットした対象を追加する結果。</param>
+    /// <param name="position">表示領域のローカル座標。</param>
+    /// <returns>ルートは常にヒット対象となるため、常に<c>true</c>。</returns>
     public bool HitTest(HitTestResult result, Offset position)
     {
         Child?.HitTest(result, position);
@@ -117,6 +158,7 @@ public class RenderView : RenderObject, IHasSingleChildRenderObject
         return true;
     }
 
+    /// <inheritdoc/>
     public override void HandleEvent(PointerEvent pointerEvent, HitTestEntry entry)
     {
         // Do nothing

--- a/src/FloatSoda/Widgets/Animation/FadeTransition.cs
+++ b/src/FloatSoda/Widgets/Animation/FadeTransition.cs
@@ -8,15 +8,29 @@ namespace FloatSoda.Widgets.Animation;
 /// 値の反映は<see cref="IAnimation{T}.Changed"/>購読によるペイントのみで行われるため、
 /// フレームごとのリビルド(SetState)は不要です。
 /// </summary>
+/// <seealso cref="RenderAnimatedOpacity"/>
 public record FadeTransition : SingleChildRenderObjectWidget<RenderAnimatedOpacity>
 {
     /// <summary>不透明度を駆動するアニメーション(0.0〜1.0)。</summary>
     public required IAnimation<double> Opacity { get; init; }
 
+    /// <summary>
+    /// 不透明度アニメーションを監視して子要素へ適用するRenderObjectを生成します。
+    /// </summary>
+    /// <returns>指定されたアニメーションを保持する新しいRenderObject。</returns>
     public override RenderAnimatedOpacity CreateRenderObject() => new()
     {
         Opacity = Opacity
     };
 
+    /// <summary>
+    /// 不透明度を駆動するアニメーションを既存のRenderObjectへ反映します。
+    /// </summary>
+    /// <param name="renderObject">このウィジェットに対応するRenderObject。</param>
+    /// <remarks>
+    /// アニメーションが置き換えられた場合、以前の変更通知の購読を解除して新しい通知を購読します。
+    /// 現在の不透明度が変化した場合は対象をPaint Dirtyとしてマークし、次のパイプライン更新時に再描画します。
+    /// 同じアニメーションが指定された場合、購読とDirty状態は変更されません。
+    /// </remarks>
     public override void UpdateRenderObject(RenderAnimatedOpacity renderObject) => renderObject.Opacity = Opacity;
 }

--- a/src/FloatSoda/Widgets/ComponentWidget.cs
+++ b/src/FloatSoda/Widgets/ComponentWidget.cs
@@ -2,43 +2,103 @@
 
 namespace FloatSoda.Widgets;
 
+/// <summary>
+/// 可変状態を持たず、現在の構成から子ウィジェットを構築するウィジェットの基底型です。
+/// </summary>
+/// <seealso cref="StatelessElement"/>
 public abstract record StatelessWidget : Widget
 {
+    /// <summary>
+    /// このウィジェットの構築結果を管理するElementを生成します。
+    /// </summary>
+    /// <returns>このウィジェットを保持する未マウントのElement。</returns>
     public override Element CreateElement() => new StatelessElement
     {
         Widget = this
     };
 
+    /// <summary>
+    /// 現在の構成から、このウィジェットの直下に配置するウィジェットを構築します。
+    /// </summary>
+    /// <param name="context">このウィジェットが配置されている構築コンテキスト。</param>
+    /// <returns>このウィジェットの直下に配置するウィジェット。</returns>
     public abstract Widget Build(IBuildContext context);
 }
 
+/// <summary>
+/// Elementの存続期間にわたって保持される可変状態を持つウィジェットの基底型です。
+/// </summary>
+/// <typeparam name="T">この状態と関連付ける具象ウィジェットの型。</typeparam>
+/// <seealso cref="State{T}"/>
+/// <seealso cref="StatefulElement{T}"/>
 public abstract record StatefulWidget<T> : Widget where T : StatefulWidget<T>
 {
+    /// <summary>
+    /// このウィジェットと状態のライフサイクルを管理するElementを生成します。
+    /// </summary>
+    /// <returns>このウィジェットを保持する未マウントのElement。</returns>
     public override Element CreateElement() => new StatefulElement<T>
     {
         Widget = this
     };
 
+    /// <summary>
+    /// このウィジェットに関連付ける新しい状態オブジェクトを生成します。
+    /// </summary>
+    /// <returns>Elementがツリーから恒久的に外れるまで保持する新しい状態オブジェクト。</returns>
     public abstract State<T> CreateState();
 }
 
+/// <summary>
+/// StatefulWidgetの可変状態と構築ライフサイクルを保持する基底型です。
+/// </summary>
+/// <typeparam name="T">この状態が関連付けられる具象ウィジェットの型。</typeparam>
+/// <seealso cref="StatefulWidget{T}"/>
+/// <seealso cref="StatefulElement{T}"/>
 public abstract class State<T> where T : StatefulWidget<T>
 {
+    /// <summary>
+    /// 現在この状態に関連付けられているウィジェットを取得または設定します。
+    /// </summary>
+    /// <remarks>Elementへのマウント前は<see langword="null"/>です。更新時は同じ状態を維持したまま新しいウィジェットへ置き換わります。</remarks>
     public T? Widget { get; set; }
 
+    /// <summary>
+    /// この状態のライフサイクルを管理するElementを取得または設定します。
+    /// </summary>
+    /// <remarks>Elementへのマウント前は<see langword="null"/>です。</remarks>
     public StatefulElement<T>? Element { get; set; }
+    /// <summary>
+    /// この状態が配置されている構築コンテキストを取得します。
+    /// </summary>
+    /// <remarks>Elementへマウントされた後から破棄されるまで使用できます。</remarks>
     public IBuildContext Context => Element!;
 
+    /// <summary>
+    /// 状態がElementへ関連付けられた直後に、一度だけ初期化を行います。
+    /// </summary>
     public virtual void InitState() { }
 
+    /// <summary>
+    /// 状態を変更する処理を実行し、このElementへ再構築を要求します。
+    /// </summary>
+    /// <param name="action">状態のフィールドを変更する処理。</param>
     protected virtual void SetState(Action action)
     {
         action();
         Element?.MarkNeedsBuild();
     }
 
+    /// <summary>
+    /// 同じElementでウィジェットの構成が更新されたときに通知を受け取ります。
+    /// </summary>
+    /// <param name="oldWidget">更新前にこの状態へ関連付けられていたウィジェット。</param>
+    /// <remarks>呼び出し時点では<see cref="Widget"/>が更新後のウィジェットを参照しています。</remarks>
     public virtual void DidUpdateWidget(T oldWidget) { }
 
+    /// <summary>
+    /// 依存するInheritedWidgetが変更されたとき、または初回構築の直前に通知を受け取ります。
+    /// </summary>
     public virtual void DidChangeDependencies() { }
 
     /// <summary>
@@ -47,5 +107,10 @@ public abstract class State<T> where T : StatefulWidget<T>
     /// </summary>
     public virtual void Dispose() { }
 
+    /// <summary>
+    /// 現在の状態と構成から、このウィジェットの直下に配置するウィジェットを構築します。
+    /// </summary>
+    /// <param name="context">この状態が関連付けられている構築コンテキスト。</param>
+    /// <returns>このウィジェットの直下に配置するウィジェット。</returns>
     public abstract Widget Build(IBuildContext context);
 }

--- a/src/FloatSoda/Widgets/Components/Text.cs
+++ b/src/FloatSoda/Widgets/Components/Text.cs
@@ -3,17 +3,47 @@ using FloatSoda.RenderObjects;
 
 namespace FloatSoda.Widgets.Components;
 
+/// <summary>
+/// 書式付きテキストを段落としてレイアウトし、描画するウィジェットです。
+/// </summary>
+/// <seealso cref="RenderParagraph"/>
 public sealed record RichText : MultiChildRenderObjectWidget<RenderParagraph>
 {
+    /// <summary>
+    /// 段落に表示する書式付きテキストを取得します。
+    /// </summary>
     public required TextSpan Text { get; init; }
 
+    /// <summary>
+    /// このウィジェットのテキストを描画するRenderObjectを生成します。
+    /// </summary>
+    /// <returns>指定された書式付きテキストを保持する新しいRenderObject。</returns>
     public override RenderParagraph CreateRenderObject() => new() { Text = Text };
 
+    /// <summary>
+    /// 表示する書式付きテキストを既存のRenderObjectへ反映します。
+    /// </summary>
+    /// <param name="renderObject">このウィジェットに対応するRenderObject。</param>
+    /// <remarks>
+    /// テキストが変更された場合、対象をLayout Dirtyとしてマークし、
+    /// 次のパイプライン更新時に段落のサイズを再計算します。
+    /// 値が変更されなかった場合、Dirty状態は変更されません。
+    /// </remarks>
     public override void UpdateRenderObject(RenderParagraph renderObject) => renderObject.Text = Text;
 }
 
+/// <summary>
+/// 単一の書式で文字列を表示するウィジェットです。
+/// </summary>
+/// <param name="Data">表示する文字列。<see langword="null"/>は指定できません。</param>
+/// <seealso cref="RichText"/>
 public sealed record Text(string Data) : StatelessWidget
 {
+    /// <summary>
+    /// 文字列を段落として描画する子ウィジェットを構築します。
+    /// </summary>
+    /// <param name="context">このウィジェットが配置されている構築コンテキスト。</param>
+    /// <returns><see cref="Data"/>を表示する<see cref="RichText"/>。</returns>
     public override Widget Build(IBuildContext context)
     {
         var text = new TextSpan(Data);

--- a/src/FloatSoda/Widgets/InheritedWidget.cs
+++ b/src/FloatSoda/Widgets/InheritedWidget.cs
@@ -2,8 +2,15 @@
 
 namespace FloatSoda.Widgets;
 
+/// <summary>
+/// 子孫Elementへ共有値を提供し、その値への依存関係を追跡するウィジェットの基底型です。
+/// </summary>
+/// <seealso cref="InheritedElement"/>
 public abstract record InheritedWidget : Widget
 {
+    /// <summary>
+    /// この共有スコープの直下に配置する子ウィジェットを取得します。
+    /// </summary>
     public required Widget Child { get; init; }
 
     /// <summary>
@@ -12,7 +19,19 @@ public abstract record InheritedWidget : Widget
     /// </summary>
     public virtual Type ScopeType => GetType();
 
+    /// <summary>
+    /// このウィジェットを祖先マップへ登録し、依存する子孫を管理するElementを生成します。
+    /// </summary>
+    /// <returns>このウィジェットを保持する未マウントのElement。</returns>
     public override Element CreateElement() => new InheritedElement() { Widget = this };
 
+    /// <summary>
+    /// 更新前後の共有値を比較し、依存する子孫Elementへ変更を通知するかを判定します。
+    /// </summary>
+    /// <param name="oldWidget">更新前に同じElementが保持していたウィジェット。</param>
+    /// <returns>依存する子孫へ変更を通知する場合は<see langword="true"/>。通知しない場合は<see langword="false"/>。</returns>
+    /// <remarks>
+    /// <see langword="true"/>を返すと、登録済みの依存Elementへ再構築を要求します。
+    /// </remarks>
     public abstract bool UpdateShouldNotify(InheritedWidget oldWidget);
 }

--- a/src/FloatSoda/Widgets/Layout/Align.cs
+++ b/src/FloatSoda/Widgets/Layout/Align.cs
@@ -4,13 +4,32 @@ using FloatSoda.RenderObjects.Layout;
 
 namespace FloatSoda.Widgets.Layout;
 
+/// <summary>
+/// 子要素を利用可能な領域内の指定位置へ配置します。
+/// </summary>
+/// <seealso cref="RenderPositionedBox"/>
 public record Align : SingleChildRenderObjectWidget<RenderPositionedBox>
 {
+    /// <summary>
+    /// 子要素を親の領域内へ配置する基準位置を取得します。
+    /// </summary>
     public Alignment Alignment { get; init; } = Alignment.Center;
+    /// <summary>
+    /// 子要素の幅に乗算して自身の幅を決める係数を取得します。
+    /// <see langword="null"/>の場合は、制約で許可された最大幅を使用します。
+    /// </summary>
     public double? WidthFactor { get; init; } = null;
+    /// <summary>
+    /// 子要素の高さに乗算して自身の高さを決める係数を取得します。
+    /// <see langword="null"/>の場合は、制約で許可された最大高さを使用します。
+    /// </summary>
     public double? HeightFactor { get; init; } = null;
 
 
+    /// <summary>
+    /// このウィジェットの配置設定を保持するRenderObjectを生成します。
+    /// </summary>
+    /// <returns>配置基準と寸法係数を保持する新しいRenderObject。</returns>
     public override RenderPositionedBox CreateRenderObject()
     {
         return new RenderPositionedBox
@@ -21,6 +40,15 @@ public record Align : SingleChildRenderObjectWidget<RenderPositionedBox>
         };
     }
 
+    /// <summary>
+    /// 配置基準と寸法係数を既存のRenderObjectへ反映します。
+    /// </summary>
+    /// <param name="renderObject">このウィジェットに対応するRenderObject。</param>
+    /// <remarks>
+    /// いずれかの値が変更された場合、対象をLayout Dirtyとしてマークし、
+    /// 次のパイプライン更新時に子要素のサイズと位置を再計算します。
+    /// すべての値が変更されなかった場合、Dirty状態は変更されません。
+    /// </remarks>
     public override void UpdateRenderObject(RenderPositionedBox renderObject)
     {
         renderObject.WidthFactor = WidthFactor;
@@ -29,10 +57,24 @@ public record Align : SingleChildRenderObjectWidget<RenderPositionedBox>
     }
 }
 
+/// <summary>
+/// 子要素を利用可能な領域の中央に配置します。
+/// </summary>
+/// <seealso cref="Align"/>
+/// <seealso cref="RenderPositionedBox"/>
 public record Center : StatelessWidget
 {
+    /// <summary>
+    /// 中央へ配置する子ウィジェットを取得します。
+    /// <see langword="null"/>の場合は子要素を配置しません。
+    /// </summary>
     public Widget? Child { get; init; } = null;
 
+    /// <summary>
+    /// 子要素を中央へ配置するウィジェットを構築します。
+    /// </summary>
+    /// <param name="context">このウィジェットが配置されている構築コンテキスト。</param>
+    /// <returns>中央配置を指定した<see cref="Align"/>。</returns>
     public override Widget Build(IBuildContext context)
     {
         return new Align()

--- a/src/FloatSoda/Widgets/Layout/ConstrainedBox.cs
+++ b/src/FloatSoda/Widgets/Layout/ConstrainedBox.cs
@@ -3,9 +3,20 @@ using FloatSoda.RenderObjects.Layout;
 
 namespace FloatSoda.Widgets.Layout;
 
+/// <summary>
+/// 親から受け取った制約へ追加の寸法制約を適用して子要素をレイアウトします。
+/// </summary>
+/// <seealso cref="RenderConstrainedBox"/>
 public record ConstrainedBox : SingleChildRenderObjectWidget<RenderConstrainedBox>
 {
+    /// <summary>
+    /// 子要素のレイアウト時に追加する寸法制約を取得します。
+    /// </summary>
     public BoxConstraints  Constraints { get; init; }
+    /// <summary>
+    /// このウィジェットの追加制約を保持するRenderObjectを生成します。
+    /// </summary>
+    /// <returns>指定された追加制約を保持する新しいRenderObject。</returns>
     public override RenderConstrainedBox CreateRenderObject() => new RenderConstrainedBox
     {
         AdditionalConstraints = Constraints

--- a/src/FloatSoda/Widgets/Layout/Flex.cs
+++ b/src/FloatSoda/Widgets/Layout/Flex.cs
@@ -4,15 +4,38 @@ using FloatSoda.RenderObjects.Layout;
 
 namespace FloatSoda.Widgets.Layout;
 
+/// <summary>
+/// 複数の子要素を主軸に沿って一列に配置します。
+/// </summary>
+/// <seealso cref="RenderFlex"/>
 public sealed record Flex : MultiChildRenderObjectWidget<RenderFlex>
 {
+    /// <summary>
+    /// 子要素を並べる主軸の方向を取得します。
+    /// </summary>
     public Axis Direction { get; init; } = Axis.Vertical;
+    /// <summary>
+    /// 主軸方向における子要素の配置方法を取得します。
+    /// </summary>
     public MainAxisAlignment MainAxisAlignment { get; init; } = MainAxisAlignment.Center;
 
+    /// <summary>
+    /// 主軸方向に確保する領域の大きさを取得します。
+    /// </summary>
     public MainAxisSize MainAxisSize { get; init; } = MainAxisSize.Max;
+    /// <summary>
+    /// 交差軸方向における子要素の配置方法を取得します。
+    /// </summary>
     public CrossAxisAlignment CrossAxisAlignment { get; init; } = CrossAxisAlignment.Center;
+    /// <summary>
+    /// 垂直方向の始端から終端へ向かう向きを取得します。
+    /// </summary>
     public VerticalDirection VerticalDirection { get; init; } = VerticalDirection.Down;
 
+    /// <summary>
+    /// このウィジェットの軸方向と配置設定を保持するRenderObjectを生成します。
+    /// </summary>
+    /// <returns>複数の子要素を一列に配置する新しいRenderObject。</returns>
     public override RenderFlex CreateRenderObject()
     {
         return new RenderFlex
@@ -25,6 +48,15 @@ public sealed record Flex : MultiChildRenderObjectWidget<RenderFlex>
         };
     }
 
+    /// <summary>
+    /// 軸方向と配置設定を既存のRenderObjectへ反映します。
+    /// </summary>
+    /// <param name="renderObject">このウィジェットに対応するRenderObject。</param>
+    /// <remarks>
+    /// いずれかの値が変更された場合、対象をLayout Dirtyとしてマークし、
+    /// 次のパイプライン更新時に子要素のサイズと位置を再計算します。
+    /// すべての値が変更されなかった場合、Dirty状態は変更されません。
+    /// </remarks>
     public override void UpdateRenderObject(RenderFlex renderObject)
     {
         renderObject.Direction = Direction;
@@ -35,13 +67,36 @@ public sealed record Flex : MultiChildRenderObjectWidget<RenderFlex>
     }
 }
 
+/// <summary>
+/// 固定された軸方向で複数の子要素を一列に配置するウィジェットの基底型です。
+/// </summary>
+/// <param name="Direction">子要素を並べる主軸の方向。</param>
+/// <seealso cref="Flex"/>
+/// <seealso cref="RenderFlex"/>
 public abstract record FlexWrapper(Axis Direction) : StatelessWidget
 {
+    /// <summary>
+    /// 主軸に沿って配置する子ウィジェットの一覧を取得します。
+    /// </summary>
     public List<Widget> Children { get; init; } = [];
+    /// <summary>
+    /// 主軸方向における子要素の配置方法を取得します。
+    /// </summary>
     public MainAxisAlignment MainAxisAlignment { get; init; } = MainAxisAlignment.Start;
+    /// <summary>
+    /// 交差軸方向における子要素の配置方法を取得します。
+    /// </summary>
     public CrossAxisAlignment CrossAxisAlignment { get; init; } = CrossAxisAlignment.Start;
+    /// <summary>
+    /// 主軸方向に確保する領域の大きさを取得します。
+    /// </summary>
     public MainAxisSize MainAxisSize { get; init; } = MainAxisSize.Max;
 
+    /// <summary>
+    /// 固定された軸方向と現在の配置設定を使用する子ウィジェットを構築します。
+    /// </summary>
+    /// <param name="context">このウィジェットが配置されている構築コンテキスト。</param>
+    /// <returns>現在の子要素と配置設定を保持する<see cref="Flex"/>。</returns>
     public override Widget Build(IBuildContext context)
     {
         return new Flex
@@ -55,6 +110,16 @@ public abstract record FlexWrapper(Axis Direction) : StatelessWidget
     }
 }
 
+/// <summary>
+/// 複数の子要素を垂直方向に一列に配置します。
+/// </summary>
+/// <seealso cref="Flex"/>
+/// <seealso cref="RenderFlex"/>
 public sealed record Column() : FlexWrapper(Axis.Vertical);
 
+/// <summary>
+/// 複数の子要素を水平方向に一列に配置します。
+/// </summary>
+/// <seealso cref="Flex"/>
+/// <seealso cref="RenderFlex"/>
 public sealed record Row() : FlexWrapper(Axis.Horizontal);

--- a/src/FloatSoda/Widgets/Layout/Padding.cs
+++ b/src/FloatSoda/Widgets/Layout/Padding.cs
@@ -21,12 +21,25 @@ internal record Padding : SingleChildRenderObjectWidget<RenderSiftedBox>
     }
 }
 
+/// <summary>
+/// 単一のRenderBoxを保持し、親データで指定されたオフセットを加えて描画するRenderObjectです。
+/// </summary>
 public class RenderSiftedBox : RenderBox, IHasSingleChildRenderObject
 {
     private readonly SingleChildContainer<RenderBox> _child;
 
+    /// <summary>
+    /// 子を持たないRenderObjectを生成します。
+    /// </summary>
     public RenderSiftedBox() => _child = new SingleChildContainer<RenderBox>(this);
 
+    /// <summary>
+    /// レイアウトおよび描画の対象となる子RenderBoxを取得または設定します。
+    /// </summary>
+    /// <remarks>
+    /// 値を置き換えると、以前の子との親子関係を解除し、新しい子をこのRenderObjectの子として登録します。
+    /// この設定だけではDirty状態を変更しません。
+    /// </remarks>
     public RenderBox? Child
     {
         get => _child.Child;
@@ -39,29 +52,57 @@ public class RenderSiftedBox : RenderBox, IHasSingleChildRenderObject
         set => Child = (RenderBox?)value;
     }
 
+    /// <summary>
+    /// 子RenderObjectへ位置オフセットを保持する親データを設定します。
+    /// </summary>
+    /// <param name="child">このRenderObjectの子として親データを設定するRenderObject。</param>
     public override void SetupParentData(RenderObject child) => child.ParentData = new BoxParentData();
 
+    /// <summary>
+    /// このRenderObjectと子RenderObjectを指定された描画パイプラインへ接続します。
+    /// </summary>
+    /// <param name="owner">接続先の描画パイプライン。パイプラインを関連付けない場合は<see langword="null"/>。</param>
     public override void Attach(RenderPipeline? owner)
     {
         base.Attach(owner);
         _child.Attach(owner);
     }
 
+    /// <summary>
+    /// 子RenderObjectを含むこのRenderObjectを描画パイプラインから切り離します。
+    /// </summary>
     public override void Detach()
     {
         base.Detach();
         _child.Detach();
     }
 
+    /// <summary>
+    /// 子RenderObjectが存在する場合に、指定された処理を一度適用します。
+    /// </summary>
+    /// <param name="visitor">子RenderObjectへ適用する処理。</param>
     public override void VisitChildren(Action<RenderObject> visitor) => _child.VisitChildren(visitor);
 
+    /// <summary>
+    /// 子RenderObjectの深さを、このRenderObjectとの親子関係に合わせて更新します。
+    /// </summary>
     public override void RedepthChildren() => VisitChildren(RedepthChild);
 
+    /// <summary>
+    /// このRenderObjectと子RenderObjectのサイズおよび位置を計算します。
+    /// </summary>
+    /// <exception cref="NotImplementedException">この型ではレイアウト処理が実装されていません。</exception>
     public override void PerformLayout()
     {
         throw new NotImplementedException();
     }
 
+    /// <summary>
+    /// 子RenderObjectを、その親データに保持された位置オフセットを加えて描画します。
+    /// </summary>
+    /// <param name="context">描画命令の記録先を提供するコンテキスト。</param>
+    /// <param name="offset">このRenderObjectを描画する親座標系での原点。</param>
+    /// <remarks>子が<see langword="null"/>の場合は何も描画しません。</remarks>
     public override void Paint(PaintingContext context, Offset offset)
     {
         var child = Child;
@@ -73,7 +114,11 @@ public class RenderSiftedBox : RenderBox, IHasSingleChildRenderObject
     }
 }
 
+/// <summary>
+/// 子RenderBoxの周囲に一定の余白を確保して配置するRenderObjectです。
+/// </summary>
 public class RenderPadding : RenderSiftedBox
 {
+    /// <summary>子RenderBoxの周囲に適用する余白を取得します。</summary>
     public required EdgeInsets Spacing { get; init; } = EdgeInsets.Zero;
 }

--- a/src/FloatSoda/Widgets/Layout/Padding.cs
+++ b/src/FloatSoda/Widgets/Layout/Padding.cs
@@ -115,8 +115,13 @@ public class RenderSiftedBox : RenderBox, IHasSingleChildRenderObject
 }
 
 /// <summary>
-/// 子RenderBoxの周囲に一定の余白を確保して配置するRenderObjectです。
+/// <see cref="Spacing"/>で指定した余白を保持するRenderObjectです。
 /// </summary>
+/// <remarks>
+/// レイアウト処理は未実装です。<see cref="Spacing"/>の値は保持されるのみで、
+/// 基底の<see cref="RenderSiftedBox.PerformLayout"/>実装により、
+/// レイアウト時に<see cref="NotImplementedException"/>がスローされます。
+/// </remarks>
 public class RenderPadding : RenderSiftedBox
 {
     /// <summary>子RenderBoxの周囲に適用する余白を取得します。</summary>

--- a/src/FloatSoda/Widgets/Layout/SizedBox.cs
+++ b/src/FloatSoda/Widgets/Layout/SizedBox.cs
@@ -3,12 +3,28 @@ using FloatSoda.RenderObjects.Layout;
 
 namespace FloatSoda.Widgets.Layout;
 
+/// <summary>
+/// 指定した幅または高さの厳密な制約を子要素へ適用します。
+/// </summary>
+/// <seealso cref="RenderConstrainedBox"/>
 public record SizedBox : SingleChildRenderObjectWidget<RenderConstrainedBox>
 {
+    /// <summary>
+    /// 子要素へ要求する幅を論理ピクセル単位で取得します。
+    /// <see langword="null"/>の場合は幅を固定しません。
+    /// </summary>
     public double? Width { get; init; } = null;
+    /// <summary>
+    /// 子要素へ要求する高さを論理ピクセル単位で取得します。
+    /// <see langword="null"/>の場合は高さを固定しません。
+    /// </summary>
     public double? Height { get; init; } = null;
 
 
+    /// <summary>
+    /// 指定された幅と高さから厳密な制約を構成するRenderObjectを生成します。
+    /// </summary>
+    /// <returns>幅と高さの制約を保持する新しいRenderObject。</returns>
     public override RenderConstrainedBox CreateRenderObject()
     {
         return new RenderConstrainedBox
@@ -17,5 +33,14 @@ public record SizedBox : SingleChildRenderObjectWidget<RenderConstrainedBox>
         };
     }
 
+    /// <summary>
+    /// 指定された幅と高さから構成した厳密な制約を既存のRenderObjectへ反映します。
+    /// </summary>
+    /// <param name="renderObject">このウィジェットに対応するRenderObject。</param>
+    /// <remarks>
+    /// 制約が変更された場合、対象をLayout Dirtyとしてマークし、
+    /// 次のパイプライン更新時に子要素のサイズを再計算します。
+    /// 制約が変更されなかった場合、Dirty状態は変更されません。
+    /// </remarks>
     public override void UpdateRenderObject(RenderConstrainedBox renderObject) => renderObject.AdditionalConstraints = BoxConstraints.TightFor(Width, Height);
 }

--- a/src/FloatSoda/Widgets/Paint/Clip.cs
+++ b/src/FloatSoda/Widgets/Paint/Clip.cs
@@ -5,11 +5,26 @@ using SkiaSharp;
 
 namespace FloatSoda.Widgets.Paint;
 
+/// <summary>
+/// 子要素の描画を楕円の内側へ制限します。
+/// </summary>
+/// <seealso cref="RenderClipOval"/>
 public record ClipOval : SingleChildRenderObjectWidget<RenderClipOval>
 {
+    /// <summary>
+    /// 楕円の外接矩形を算出するクリッパーを取得します。
+    /// <see langword="null"/>の場合は、このウィジェットの領域全体を外接矩形として使用します。
+    /// </summary>
     public CustomClipper<SKRect>? Clipper { get; init; } = null;
+    /// <summary>
+    /// クリップ境界の描画方式を取得します。
+    /// </summary>
     public Clip ClipBehavior { get; init; } = Clip.Antialias;
 
+    /// <summary>
+    /// このウィジェットの楕円クリップを適用するRenderObjectを生成します。
+    /// </summary>
+    /// <returns>クリッパーと描画方式を保持する新しいRenderObject。</returns>
     public override RenderClipOval CreateRenderObject()
     {
         return new RenderClipOval
@@ -19,6 +34,15 @@ public record ClipOval : SingleChildRenderObjectWidget<RenderClipOval>
         };
     }
 
+    /// <summary>
+    /// クリッパーと描画方式を既存のRenderObjectへ反映します。
+    /// </summary>
+    /// <param name="renderObject">このウィジェットに対応するRenderObject。</param>
+    /// <remarks>
+    /// クリップ領域の再計算が必要な変更、または描画方式の変更があった場合、
+    /// 対象をPaint Dirtyとしてマークし、次のパイプライン更新時に再描画します。
+    /// 再クリップが不要で描画方式も変更されなかった場合、Dirty状態は変更されません。
+    /// </remarks>
     public override void UpdateRenderObject(RenderClipOval renderObject)
     {
         renderObject.Clipper = Clipper;
@@ -26,12 +50,27 @@ public record ClipOval : SingleChildRenderObjectWidget<RenderClipOval>
     }
 }
 
+/// <summary>
+/// 子要素の描画を矩形の内側へ制限します。
+/// </summary>
+/// <seealso cref="RenderClipRect"/>
 public record ClipRect : SingleChildRenderObjectWidget<RenderClipRect>
 {
+    /// <summary>
+    /// クリップ矩形を算出するクリッパーを取得します。
+    /// <see langword="null"/>の場合は、このウィジェットの領域全体を使用します。
+    /// </summary>
     public CustomClipper<SKRect>? Clipper { get; init; } = null;
+    /// <summary>
+    /// クリップ境界の描画方式を取得します。
+    /// </summary>
     public Clip ClipBehavior { get; init; } = Clip.Antialias;
 
 
+    /// <summary>
+    /// このウィジェットの矩形クリップを適用するRenderObjectを生成します。
+    /// </summary>
+    /// <returns>クリッパーと描画方式を保持する新しいRenderObject。</returns>
     public override RenderClipRect CreateRenderObject()
     {
         return new RenderClipRect
@@ -41,6 +80,15 @@ public record ClipRect : SingleChildRenderObjectWidget<RenderClipRect>
         };
     }
 
+    /// <summary>
+    /// クリッパーと描画方式を既存のRenderObjectへ反映します。
+    /// </summary>
+    /// <param name="renderObject">このウィジェットに対応するRenderObject。</param>
+    /// <remarks>
+    /// クリップ領域の再計算が必要な変更、または描画方式の変更があった場合、
+    /// 対象をPaint Dirtyとしてマークし、次のパイプライン更新時に再描画します。
+    /// 再クリップが不要で描画方式も変更されなかった場合、Dirty状態は変更されません。
+    /// </remarks>
     public override void UpdateRenderObject(RenderClipRect renderObject)
     {
         renderObject.Clipper = Clipper;
@@ -48,13 +96,31 @@ public record ClipRect : SingleChildRenderObjectWidget<RenderClipRect>
     }
 }
 
+/// <summary>
+/// 子要素の描画を角丸矩形の内側へ制限します。
+/// </summary>
+/// <seealso cref="RenderClipRoundRect"/>
 public record ClipRoundRect : SingleChildRenderObjectWidget<RenderClipRoundRect>
 {
+    /// <summary>
+    /// 既定のクリップ領域へ適用する角の半径を取得または設定します。
+    /// </summary>
     public BorderRadius BorderRadius;
+    /// <summary>
+    /// 角丸クリップ矩形を算出するクリッパーを取得します。
+    /// <see langword="null"/>の場合は、<see cref="BorderRadius"/>を領域全体へ適用します。
+    /// </summary>
     public CustomClipper<SKRoundRect>? Clipper { get; init; } = null;
+    /// <summary>
+    /// クリップ境界の描画方式を取得します。
+    /// </summary>
     public Clip ClipBehavior { get; init; } = Clip.Antialias;
 
 
+    /// <summary>
+    /// このウィジェットの角丸矩形クリップを適用するRenderObjectを生成します。
+    /// </summary>
+    /// <returns>角の半径、クリッパー、および描画方式を保持する新しいRenderObject。</returns>
     public override RenderClipRoundRect CreateRenderObject()
     {
         return new RenderClipRoundRect
@@ -65,6 +131,15 @@ public record ClipRoundRect : SingleChildRenderObjectWidget<RenderClipRoundRect>
         };
     }
 
+    /// <summary>
+    /// 角の半径、クリッパー、および描画方式を既存のRenderObjectへ反映します。
+    /// </summary>
+    /// <param name="renderObject">このウィジェットに対応するRenderObject。</param>
+    /// <remarks>
+    /// クリップ領域の再計算が必要なクリッパーの変更、または描画方式の変更があった場合、
+    /// 対象をPaint Dirtyとしてマークし、次のパイプライン更新時に再描画します。
+    /// 角の半径だけが変更された場合、この更新ではDirty状態を変更しません。
+    /// </remarks>
     public override void UpdateRenderObject(RenderClipRoundRect renderObject)
     {
         renderObject.BorderRadius = BorderRadius;
@@ -73,12 +148,27 @@ public record ClipRoundRect : SingleChildRenderObjectWidget<RenderClipRoundRect>
     }
 }
 
+/// <summary>
+/// 子要素の描画を任意のパスの内側へ制限します。
+/// </summary>
+/// <seealso cref="RenderClipPath"/>
 public record ClipCustomPath : SingleChildRenderObjectWidget<RenderClipPath>
 {
+    /// <summary>
+    /// クリップパスを算出するクリッパーを取得します。
+    /// <see langword="null"/>の場合は、このウィジェットの領域全体を囲む矩形パスを使用します。
+    /// </summary>
     public CustomClipper<SKPath>? Clipper { get; init; } = null;
+    /// <summary>
+    /// クリップ境界の描画方式を取得します。
+    /// </summary>
     public Clip ClipBehavior { get; init; } = Clip.Antialias;
 
 
+    /// <summary>
+    /// このウィジェットのパスクリップを適用するRenderObjectを生成します。
+    /// </summary>
+    /// <returns>クリッパーと描画方式を保持する新しいRenderObject。</returns>
     public override RenderClipPath CreateRenderObject()
     {
         return new RenderClipPath()
@@ -88,6 +178,15 @@ public record ClipCustomPath : SingleChildRenderObjectWidget<RenderClipPath>
         };
     }
 
+    /// <summary>
+    /// クリッパーと描画方式を既存のRenderObjectへ反映します。
+    /// </summary>
+    /// <param name="renderObject">このウィジェットに対応するRenderObject。</param>
+    /// <remarks>
+    /// クリップ領域の再計算が必要な変更、または描画方式の変更があった場合、
+    /// 対象をPaint Dirtyとしてマークし、次のパイプライン更新時に再描画します。
+    /// 再クリップが不要で描画方式も変更されなかった場合、Dirty状態は変更されません。
+    /// </remarks>
     public override void UpdateRenderObject(RenderClipPath renderObject)
     {
         renderObject.Clipper = Clipper;

--- a/src/FloatSoda/Widgets/Paint/ColoredBox.cs
+++ b/src/FloatSoda/Widgets/Paint/ColoredBox.cs
@@ -3,10 +3,21 @@ using FloatSoda.RenderObjects.Painting;
 
 namespace FloatSoda.Widgets.Paint;
 
+/// <summary>
+/// 自身の領域を単色で塗りつぶし、その上に子要素を描画します。
+/// </summary>
+/// <seealso cref="RenderColoredBox"/>
 public record ColoredBox : SingleChildRenderObjectWidget<RenderColoredBox>
 {
+    /// <summary>
+    /// 背景の塗りつぶしに使用する色を取得します。
+    /// </summary>
     public Color Color { get; init; }
     
+    /// <summary>
+    /// このウィジェットの背景色を描画するRenderObjectを生成します。
+    /// </summary>
+    /// <returns>指定された背景色を保持する新しいRenderObject。</returns>
     public override RenderColoredBox CreateRenderObject()
     {
         return new RenderColoredBox
@@ -15,5 +26,14 @@ public record ColoredBox : SingleChildRenderObjectWidget<RenderColoredBox>
         };
     }
 
+    /// <summary>
+    /// 背景色を既存のRenderObjectへ反映します。
+    /// </summary>
+    /// <param name="renderObject">このウィジェットに対応するRenderObject。</param>
+    /// <remarks>
+    /// 色が変更された場合、対象をPaint Dirtyとしてマークし、
+    /// 次のパイプライン更新時に背景を再描画します。
+    /// 色が変更されなかった場合、Dirty状態は変更されません。
+    /// </remarks>
     public override void UpdateRenderObject(RenderColoredBox renderObject) => renderObject.Color = Color;
 }

--- a/src/FloatSoda/Widgets/Paint/Image.cs
+++ b/src/FloatSoda/Widgets/Paint/Image.cs
@@ -3,10 +3,22 @@ using FloatSoda.RenderObjects;
 
 namespace FloatSoda.Widgets.Paint;
 
+/// <summary>
+/// 画像プロバイダーから読み込んだ画像を自身の領域へ描画します。
+/// </summary>
+/// <seealso cref="RenderImage"/>
 public record Image : SingleChildRenderObjectWidget<RenderImage>
 {
+    /// <summary>
+    /// 描画する画像を読み込むプロバイダーを取得します。
+    /// </summary>
     public required ImageProvider ImageProvider { get; init; }
 
+    /// <summary>
+    /// プロバイダーから画像を読み込み、その画像を描画するRenderObjectを生成します。
+    /// </summary>
+    /// <returns>読み込んだ画像を所有する新しいRenderObject。</returns>
+    /// <remarks>このメソッドの呼び出し中に画像の読み込みを実行します。</remarks>
     public override RenderImage CreateRenderObject()
     {
         return new RenderImage()

--- a/src/FloatSoda/Widgets/WindowWidget.cs
+++ b/src/FloatSoda/Widgets/WindowWidget.cs
@@ -38,8 +38,21 @@ public abstract record WindowWidget : InheritedWidget
         context.DependOnInheritedWidgetOfExactType<WindowWidget>() ??
         throw new InvalidOperationException("WindowWidgetが祖先に見つかりません。");
 
+    /// <summary>
+    /// ウィンドウ設定が更新前から変化したかを判定します。
+    /// </summary>
+    /// <param name="oldWidget">更新前に同じElementが保持していたウィンドウウィジェット。</param>
+    /// <returns>レコードとして等しくない場合は<see langword="true"/>。等しい場合は<see langword="false"/>。</returns>
+    /// <remarks>
+    /// <see langword="true"/>を返すと、このウィンドウ設定に依存するElementへ再構築を要求します。
+    /// </remarks>
     public override bool UpdateShouldNotify(InheritedWidget oldWidget) => !Equals(oldWidget, this);
 
+    /// <summary>
+    /// ウィンドウ設定の共有とルート描画領域へのサイズ反映を管理するElementを生成します。
+    /// </summary>
+    /// <returns>このウィンドウウィジェットを保持する未マウントのElement。</returns>
+    /// <seealso cref="WindowElement"/>
     public override Element CreateElement() => new WindowElement { Widget = this };
 }
 


### PR DESCRIPTION
## Summary
- `docs/DocumentationComments.md` の規約に沿って、CS1591警告(ドキュメントコメント欠落)のあったpublicメンバーへXMLドキュメントコメントを追加(Wave 2)
- 対象: `RenderObjects/`具象クラス(RenderConstrainedBox, RenderFlex, RenderCustomClip等)、`Widgets/`具象クラス(Text, Align, Clip等)、`Core/`(RenderPipeline, WidgetBinding等)、`Animation/`、`Geometrics/`(Color, BoxConstraints等)、`FloatSoda.Engine/OverlayWindow.cs`
- これにより **`FloatSoda` / `FloatSoda.Abstractions` / `FloatSoda.Rendering` / `FloatSoda.Engine` のCS1591警告が実質ゼロ**になった(残るのは実験段階の`FloatSoda.Hooks`と、UI系プロジェクトの軽微なoverrideメソッド数件のみ)
- ロジック・シグネチャの変更なし(コメント追加のみ)
- Codex CLIへの委任(codex-runner)+ 人間による独立検証(build/diff/test)で作成。#183(Wave 1)の後続

## Test plan
- [x] `dotnet build FloatSoda.slnx` — 0エラー
- [x] `dotnet test tests/FloatSoda.Test` — 187/187件成功
- [x] `dotnet test tests/FloatSoda.Rendering.Test` — 8/8件成功
- [x] 対象ファイルの `git diff` がコメント行の追加のみであることを確認(ロジック変更なし)
- [x] 対象ファイルのCS1591警告が0件であることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)