### PR TITLE
docs: UI/Cream/FizzyPop/Testingの残りドキュメントコメントを整備

### DIFF
--- a/src/FloatSoda.Testing/RenderObjectBitmapRenderer.cs
+++ b/src/FloatSoda.Testing/RenderObjectBitmapRenderer.cs
@@ -12,6 +12,12 @@ public sealed class RenderObjectBitmapRenderer
 {
     private readonly LayerBitmapRenderer _layerRenderer = new();
 
+    /// <summary>
+    /// 指定したRenderObjectツリーを単独のパイプラインでレイアウト・ペイントし、結果をBitmapへ描画します。
+    /// </summary>
+    /// <param name="renderObject">描画対象のルートとなるRenderBox。<see langword="null"/>は指定できません。</param>
+    /// <param name="imageSize">出力するBitmapのピクセルサイズ。</param>
+    /// <returns>描画結果を格納したBitmap。レイヤーが生成されなかった場合は空のBitmap。</returns>
     public SKBitmap Render(RenderBox renderObject, SKSizeI imageSize)
     {
         ArgumentNullException.ThrowIfNull(renderObject);

--- a/src/FloatSoda.Testing/WidgetBitmapRenderer.cs
+++ b/src/FloatSoda.Testing/WidgetBitmapRenderer.cs
@@ -14,6 +14,12 @@ public sealed class WidgetBitmapRenderer
 {
     private readonly LayerBitmapRenderer _layerRenderer = new();
 
+    /// <summary>
+    /// 指定したWidgetツリーを単独のパイプラインでビルド・レイアウト・ペイントし、結果をBitmapへ描画します。
+    /// </summary>
+    /// <param name="widget">描画対象のルートとなるWidget。<see langword="null"/>は指定できません。</param>
+    /// <param name="imageSize">出力するBitmapのピクセルサイズ。</param>
+    /// <returns>描画結果を格納したBitmap。レイヤーが生成されなかった場合は空のBitmap。</returns>
     public SKBitmap Render(Widget widget, SKSizeI imageSize)
     {
         ArgumentNullException.ThrowIfNull(widget);

--- a/src/FloatSoda.UI.Cream/Button.cs
+++ b/src/FloatSoda.UI.Cream/Button.cs
@@ -23,6 +23,7 @@ public record Button : StatelessWidget
     /// <summary>見た目のスタイル。未指定なら祖先の <see cref="CreamTheme"/>、それも無ければ既定値。</summary>
     public ButtonStyle? Style { get; init; }
 
+    /// <inheritdoc/>
     public override Widget Build(IBuildContext context)
     {
         return new ButtonBase

--- a/src/FloatSoda.UI.Cream/CreamTheme.cs
+++ b/src/FloatSoda.UI.Cream/CreamTheme.cs
@@ -19,5 +19,6 @@ public record CreamTheme : InheritedWidget
     public static CreamTheme? Of(IBuildContext context) =>
         context.DependOnInheritedWidgetOfExactType<CreamTheme>();
 
+    /// <inheritdoc/>
     public override bool UpdateShouldNotify(InheritedWidget oldWidget) => !Equals(oldWidget, this);
 }

--- a/src/FloatSoda.UI.FizzyPop/Button.cs
+++ b/src/FloatSoda.UI.FizzyPop/Button.cs
@@ -23,6 +23,7 @@ public record Button : StatelessWidget
     /// <summary>見た目のスタイル。未指定なら祖先の <see cref="FizzyPopTheme"/>、それも無ければ既定値。</summary>
     public ButtonStyle? Style { get; init; }
 
+    /// <inheritdoc/>
     public override Widget Build(IBuildContext context)
     {
         return new ButtonBase

--- a/src/FloatSoda.UI.FizzyPop/FizzyPopTheme.cs
+++ b/src/FloatSoda.UI.FizzyPop/FizzyPopTheme.cs
@@ -19,5 +19,6 @@ public record FizzyPopTheme : InheritedWidget
     public static FizzyPopTheme? Of(IBuildContext context) =>
         context.DependOnInheritedWidgetOfExactType<FizzyPopTheme>();
 
+    /// <inheritdoc/>
     public override bool UpdateShouldNotify(InheritedWidget oldWidget) => !Equals(oldWidget, this);
 }

--- a/src/FloatSoda.UI/ButtonBase.cs
+++ b/src/FloatSoda.UI/ButtonBase.cs
@@ -19,11 +19,17 @@ public record ButtonBase : StatefulWidget<ButtonBase>
     /// <summary>操作を無効化するかどうか。</summary>
     public bool IsDisabled { get; init; }
 
+    /// <inheritdoc/>
     public override State<ButtonBase> CreateState() => new ButtonBaseState();
 }
 
+/// <summary>
+/// <see cref="ButtonBase"/>の押下・無効化状態を管理し、<see cref="InteractionState"/>を
+/// <see cref="ButtonBase.Builder"/>へ渡して見た目を構築する状態です。
+/// </summary>
 public class ButtonBaseState : State<ButtonBase>
 {
+    /// <inheritdoc/>
     public override Widget Build(IBuildContext context)
     {
         // TODO: ジェスチャ/ヒットテスト実装後に GestureDetector を配線する


### PR DESCRIPTION
## Summary
- `docs/DocumentationComments.md` の規約に沿って、CS1591警告のあった残りのoverrideメソッド等へXMLドキュメントコメントを追加(Wave 3、最終)
- 対象: `FloatSoda.UI/ButtonBase.cs`(CreateState/ButtonBaseState/Build)、`FloatSoda.UI.Cream`/`FizzyPop`のButton.Build・Theme.UpdateShouldNotify、`FloatSoda.Testing`の各Render()
- 契約が基底実装と完全に同一なoverrideは`<inheritdoc/>`を使用
- これで**`FloatSoda.Hooks`(実験段階、スコープ外)を除く全プロジェクトでCS1591警告がゼロ**になる
- ロジック・シグネチャの変更なし(コメント追加のみ)。#183(Wave1)・#185(Wave2)の後続、今回で整備完了

## Test plan
- [x] `dotnet test tests/FloatSoda.Test` — 187/187件成功
- [x] 対象7ファイルのCS1591警告が0件であることを確認
- [x] `git diff` がコメント行の追加のみであることを確認(ロジック変更なし)

🤖 Generated with [Claude Code](https://claude.com/claude-code)